### PR TITLE
Chore/update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 build.properties
-dspace/target
-*/target
 .idea
-**/*.iml
-**/**/**/*.iml
-**/**/*.iml
+
+# ignore all .iml files in the directory hierarchy, except those
+# already under version control
+**/*.iml 
+
+# ignore all directories named 'target/", regardless of where they are
+# in the directory hierarchy.
+target/

--- a/target/antrun/build-Encode any UTF-8 chars in properties.xml
+++ b/target/antrun/build-Encode any UTF-8 chars in properties.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<project name="maven-antrun-" default="Encode any UTF-8 chars in properties"  >
-<target name="Encode any UTF-8 chars in properties">
-  <native2ascii src="/Users/katepechekhonova/vagrant-dspace/dspace-src" includes="*.properties" encoding="UTF8" dest="/Users/katepechekhonova/vagrant-dspace/dspace-src/target"/>
-</target>
-</project>


### PR DESCRIPTION
## Overview
* edited `.gitignore` to reduce the number of files that `git` reports as having been modified after a `mvn package` command
* all `target/` directories at any point in the directory hierarchy will be ignored except one that is already under version control: `dspace/modules/lni/target`
* removed one ephemeral file that was under version control: `target/antrun/build-Encode any UTF-8 chars in properties.xml`
* tweaked `.gitignore` rule for `.iml` files to take full advantage of recursive `**` functionality added in `git 1.8.2+`
