### PR TITLE
FDA-234 : maintain UX for collections that have template items with rights statements

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -17,6 +17,12 @@
     <name-map collection-handle="default" form-name="traditional" />
   </form-map>
   <form-map>
+    <name-map collection-handle="2451/29947" form-name="traditional-require-rights" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/34305" form-name="traditional-require-rights" />
+  </form-map>
+  <form-map>
     <name-map collection-handle="2451/60387" form-name="Tandon" />
   </form-map>
   <form-map>
@@ -375,7 +381,8 @@
         </field>
       </page>
     </form>
-    <form name="Tandon">
+
+    <form name="traditional-require-rights">
       <page number="1">
         <field>
 
@@ -387,6 +394,202 @@
           <input-type>name</input-type>
           <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
           <required>You must  add at least one author</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Other Titles</label>
+          <input-type>onebox</input-type>
+          <hint>If the item has any alternative titles, please enter them below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable. *Required*&lt;/em&gt;</hint>
+
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Series/Report No.</label>
+          <input-type>series</input-type>
+          <hint>Enter the series and number assigned to this item by your community.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>sponsorship</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Sponsors</label>
+
+          <input-type>textarea</input-type>
+          <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required>You must enter rights information</required>
+        </field>
+      </page>
+    </form>
+
+    <form name="Tandon">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must add at least one author</required>
         </field>
 
         <field>
@@ -907,7 +1110,7 @@
           <label>Rights</label>
           <input-type>textarea</input-type>
           <hint> Enter information on item's rights in this box. </hint>
-          <required></required>
+          <required>You must enter rights information</required>
         </field>
         <field>
           <dc-schema>dc</dc-schema>
@@ -1146,7 +1349,7 @@
           <label>Rights</label>
           <input-type>textarea</input-type>
           <hint> Enter information on item's rights in this box. </hint>
-          <required></required>
+          <required>You must enter rights information</required>
         </field>
 
       </page>
@@ -1533,8 +1736,8 @@
         </field>
       </page>
     </form>
-    <form name="Collins">
 
+    <form name="Collins">
       <page number="1">
         <field>
           <dc-schema>dc</dc-schema>
@@ -1754,10 +1957,11 @@
 
           <input-type>textarea</input-type>
           <hint> Enter information on item's rights in this box. </hint>
-          <required></required>
+          <required>You must enter rights information</required>
         </field>
       </page>
     </form>
+
     <form name="Ramlila">
       <page number="1">
         <field>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -3,4853 +3,4853 @@
 
 <input-forms>
 
- <!-- The form-map maps collection handles to forms. Faculty Digital Archive does not       -->
- <!-- require that a collection's name be unique, even within a community .-->
- <!-- Faculty Digital Archive does however insure that each collection's handle is unique.  -->
- <!-- Form-map provides the means to associate a unique collection name    -->
- <!-- with a form. The form-map also provides the special handle "default" -->
- <!-- (which is never a collection), here mapped to "traditional". Any     -->
+  <!-- The form-map maps collection handles to forms. Faculty Digital Archive does not       -->
+  <!-- require that a collection's name be unique, even within a community .-->
+  <!-- Faculty Digital Archive does however insure that each collection's handle is unique.  -->
+  <!-- Form-map provides the means to associate a unique collection name    -->
+  <!-- with a form. The form-map also provides the special handle "default" -->
+  <!-- (which is never a collection), here mapped to "traditional". Any     -->
 
- <!-- collection which does not appear in this map will be associated with -->
- <!-- the mapping for handle "default".                                    -->
+  <!-- collection which does not appear in this map will be associated with -->
+  <!-- the mapping for handle "default".                                    -->
 
- <form-map>
-   <name-map collection-handle="default" form-name="traditional" />
- </form-map>
- <form-map>
+  <form-map>
+    <name-map collection-handle="default" form-name="traditional" />
+  </form-map>
+  <form-map>
     <name-map collection-handle="2451/60387" form-name="Tandon" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/37860" form-name="Laefer" />
- </form-map>
- <form-map>
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/37860" form-name="Laefer" />
+  </form-map>
+  <form-map>
     <name-map collection-handle="2451/44428" form-name="Relics" />
- </form-map>
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/26402" form-name="Stern" />
- </form-map>
+    <name-map collection-handle="2451/26402" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/27738" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/14813" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25921" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/27738" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/14813" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25921" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25922" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25925" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/14090" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25922" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25925" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/14090" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/14093" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/14094" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25923" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/14093" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/14094" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25923" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25924" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25926" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25928" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25924" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25926" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25928" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25929" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25929" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25930" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25929" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25929" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25930" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25931" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25932" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25933" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/17597" form-name="Ramlila" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25931" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25932" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25933" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/17597" form-name="Ramlila" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25934" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/14942" form-name="Stern" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/25929" form-name="Stern" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25934" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/14942" form-name="Stern" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/25929" form-name="Stern" />
+  </form-map>
 
- <form-map>
-   <name-map collection-handle="2451/25929" form-name="Stern" />
- </form-map>
   <form-map>
-   <name-map collection-handle="2451/28318" form-name="Collins" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/29653" form-name="Collins" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/29676" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/25929" form-name="Stern" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/29655" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/28318" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/29656" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/29653" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/28320" form-name="Collins" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/29658" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/29676" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/29659" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/29655" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/29898" form-name="Collins" />
- </form-map>
+    <name-map collection-handle="2451/29656" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/33560" form-name="Aruna" />
- </form-map>
+    <name-map collection-handle="2451/28320" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/33605" form-name="Aruna1" />
- </form-map>
+    <name-map collection-handle="2451/29658" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/42113" form-name="Aruna1" />
- </form-map>
+    <name-map collection-handle="2451/29659" form-name="Collins" />
+  </form-map>
   <form-map>
-   <name-map collection-handle="2451/33611" form-name="DataS" />
- </form-map>
- <form-map>
-   <name-map collection-handle="2451/34304" form-name="therapy" />
- </form-map>
+    <name-map collection-handle="2451/29898" form-name="Collins" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/33560" form-name="Aruna" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/33605" form-name="Aruna1" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/42113" form-name="Aruna1" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/33611" form-name="DataS" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/34304" form-name="therapy" />
+  </form-map>
   <form-map>
     <name-map collection-handle="2451/34841" form-name="gallatin" />
   </form-map>
-<form-map>
-   <name-map collection-handle="2451/44191" form-name="Jones" />
-</form-map>
-<form-map>
-   <name-map collection-handle="2451/44193" form-name="Jones" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/44191" form-name="Jones" />
+  </form-map>
+  <form-map>
+    <name-map collection-handle="2451/44193" form-name="Jones" />
+  </form-map>
 
-<form-map>
-   <name-map collection-handle="2451/44466" form-name="Jones" />
- </form-map>
+  <form-map>
+    <name-map collection-handle="2451/44466" form-name="Jones" />
+  </form-map>
 
   <!-- The form-definitions map lays out the detailed definition of all the -->
- <!-- submission forms.Each separate form set has a unique name as an      -->
-
- <!-- attribute. This name matches one of the names in the form-map. One   -->
- <!-- named form set has the name "traditional"; as this name suggests,    -->
- <!-- it is the old style and is also the default, which gets used when    -->
- <!-- the specified collection has no correspondingly named form set.      -->
- <!--                                                                      -->
- <!-- Each form set contains an ordered set of pages; each page defines    -->
- <!-- one submission metadata entry screen. Each page has an ordered list  -->
- <!-- of field definitions, Each field definition corresponds to one       -->
- <!-- metatdata entry (a so-called row), which has a DC element name, a    -->
-
- <!-- displayed label, a text string prompt which is called a hint , and   -->
- <!-- an input-type. Each field also may hold optional elements: DC        -->
- <!-- qualifier name, a repeatable flag, and a text string whose presence  -->
- <!-- serves as a 'this field is required' flag.                           -->
- <form-definitions>
-
-   <form name="traditional">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
- <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
-         <required>You must  add at least one author</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier>alternative</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Other Titles</label>
-         <input-type>onebox</input-type>
-         <hint>If the item has any alternative titles, please enter them below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of Issue</label>
-         <input-type>date</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
-                        below.  You can leave out the day and/or month if they aren't
-                        applicable. *Required*&lt;/em&gt;</hint>
-
-         <required>You must enter at least the year.</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Citation</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofseries</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Series/Report No.</label>
-         <input-type>series</input-type>
-         <hint>Enter the series and number assigned to this item by your community.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-         <required></required>
-       </field>
-
-      <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-       </field>
-        
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>abstract</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Abstract</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the abstract of the item below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>sponsorship</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Sponsors</label>
-
-         <input-type>textarea</input-type>
-         <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-     <form name="Tandon">
-            <page number="1">
-              <field>
-
-               <dc-schema>dc</dc-schema>
-                   <dc-element>contributor</dc-element>
-                   <dc-qualifier>author</dc-qualifier>
-                   <repeatable>true</repeatable>
-                   <label>Authors</label>
-                           <input-type>name</input-type>
-           <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
-                   <required>You must  add at least one author</required>
-                 </field>
-
-                 <field>
-               <dc-schema>dc</dc-schema>
-                   <dc-element>title</dc-element>
-                   <dc-qualifier></dc-qualifier>
-
-                   <repeatable>false</repeatable>
-                   <label>Title</label>
-                   <input-type>onebox</input-type>
-                   <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-                   <required>You must enter a main title for this item.</required>
-
-                 </field>
-
-                 <field>
-               <dc-schema>dc</dc-schema>
-                  <dc-element>title</dc-element>
-                   <dc-qualifier>alternative</dc-qualifier>
-                   <repeatable>true</repeatable>
-
-                  <label>Other Titles</label>
-                  <input-type>onebox</input-type>
-                  <hint>If the item has any alternative titles, please enter them below.</hint>
-                  <required></required>
-                </field>
-                <field>
-              <dc-schema>dc</dc-schema>
-                  <dc-element>date</dc-element>
-                  <dc-qualifier>issued</dc-qualifier>
-                  <repeatable>false</repeatable>
-                  <label>Date of Issue</label>
-                  <input-type>date</input-type>
-                  <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
-                                 below.  You can leave out the day and/or month if they aren't
-                                 applicable. *Required*&lt;/em&gt;</hint>
-                  <required>You must enter at least the year.</required>
-                </field>
-                 <field>
-                          <dc-schema>dc</dc-schema>
-                  <dc-element>identifier</dc-element>
-                  <dc-qualifier>citation</dc-qualifier>
-                  <repeatable>false</repeatable>
-                  <label>Citation</label>
-                  <input-type>onebox</input-type>
-                  <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-                  <required></required>
-                </field>
-                <field>
-                          <dc-schema>dc</dc-schema>
-                  <dc-element>identifier</dc-element>
-                  <dc-qualifier>DOI</dc-qualifier>
-                  <repeatable>true</repeatable>
-                  <label>DOI</label>
-                  <input-type>onebox</input-type>
-                  <hint></hint>
-                  <required></required>
-                </field>
-          <field>
-              <dc-schema>dc</dc-schema>
-                  <dc-element>description</dc-element>
-                  <dc-qualifier>abstract</dc-qualifier>
-                  <repeatable>false</repeatable>
-                  <label>Abstract</label>
-                  <input-type>textarea</input-type>
-                  <hint> Enter the abstract of the item below. </hint>
-                  <required></required>
-                </field>
-          <field>
-              <dc-schema>dc</dc-schema>
-                  <dc-element>description</dc-element>
-                  <dc-qualifier>firstPage</dc-qualifier>
-                  <repeatable>false</repeatable>
-                  <label>First page</label>
-                  <input-type>textarea</input-type>
-                  <hint> Enter the first page of the article below. </hint>
-                  <required></required>
-                </field>
-          <field>
-         <dc-schema>dc</dc-schema>
-                  <dc-element>description</dc-element>
-                  <dc-qualifier>lastPage</dc-qualifier>
-                  <repeatable>false</repeatable>
-                  <label>Last Page</label>
-                  <input-type>textarea</input-type>
-                  <hint> Enter the last page of the article below. </hint>
-                  <required></required>
-             </field>
-         <field>
-                          <dc-schema>dc</dc-schema>
-                  <dc-element>type</dc-element>
-                  <dc-qualifier></dc-qualifier>
-                  <repeatable>true</repeatable>
-                  <label>Type</label>
-                  <input-type value-pairs-name="common_types">dropdown</input-type>
-                  <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-                  <required>You must enter the types of item (recording, oral; document)</required>
-                </field>
-              </page>
-          </form>
-   <form name="Relics">
-         <page number="1">
-             <field>
-
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>contributor</dc-element>
-                 <dc-qualifier>author</dc-qualifier>
-                 <repeatable>true</repeatable>
-                 <label>Authors</label>
-                 <input-type>name</input-type>
-                 <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
-                 <required>You must  add at least one author</required>
-             </field>
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>title</dc-element>
-                 <dc-qualifier></dc-qualifier>
-
-                 <repeatable>false</repeatable>
-                 <label>Title</label>
-                 <input-type>onebox</input-type>
-                 <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-                 <required>You must enter a main title for this item.</required>
-
-             </field>
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-
-                 <dc-element>date</dc-element>
-                 <dc-qualifier>issued</dc-qualifier>
-                 <repeatable>false</repeatable>
-                 <label>Date of Issue</label>
-                 <input-type>date</input-type>
-                 <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
-                     below.  You can leave out the day and/or month if they aren't
-                     applicable. *Required*&lt;/em&gt;</hint>
-
-                 <required>You must enter at least the year.</required>
-             </field>
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>publisher</dc-element>
-                 <dc-qualifier></dc-qualifier>
-                 <repeatable>false</repeatable>
-
-                 <label>Publisher</label>
-                 <input-type>onebox</input-type>
-                 <hint>Enter the name of the publisher of this item.</hint>
-                 <required></required>
-             </field>
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>type</dc-element>
-                 <dc-qualifier></dc-qualifier>
-                 <repeatable>false</repeatable>
-
-                 <label>Type</label>
-                 <input-type>onebox</input-type>
-                 <hint> Enter the type of the resource </hint>
-                 <required></required>
-             </field>
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>description</dc-element>
-                 <dc-qualifier></dc-qualifier>
-
-                 <repeatable>false</repeatable>
-                 <label>Description</label>
-                 <input-type>textarea</input-type>
-                 <hint> Enter description of the item below. </hint>
-                 <required></required>
-             </field>
-
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>coverage</dc-element>
-                 <dc-qualifier>spatial</dc-qualifier>
-
-                 <repeatable>false</repeatable>
-                 <label>Country</label>
-                 <input-type value-pairs-name="relics_countries">dropdown</input-type>
-                 <hint> Select the name of the country from the list below </hint>
-                 <required></required>
-             </field>
-
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>source</dc-element>
-                 <dc-qualifier></dc-qualifier>
-                 <repeatable>false</repeatable>
-                 <label>Source</label>
-
-                 <input-type>onebox</input-type>
-                 <hint> Enter the names of the source </hint>
-                 <required></required>
-             </field>
-             <field>
-                 <dc-schema>dc</dc-schema>
-                 <dc-element>rights</dc-element>
-                 <dc-qualifier></dc-qualifier>
-                 <repeatable>false</repeatable>
-
-                 <label>Rights</label>
-                 <input-type>textarea</input-type>
-                 <hint> Enter information on item's rights in this box. </hint>
-                 <required></required>
-             </field>
-
-         </page>
-     </form>
-   <form name="therapy">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
-
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-      
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Issue Date</label>
-         <input-type>date</input-type>
-         <hint> </hint>
-
-         <required>You must enter at least the year.</required>
-       </field>
-
-      <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-
-         <hint></hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>category</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Category</label>
-         <input-type value-pairs-name="music_subjects">dropdown</input-type>
-         <hint>Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key</hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-   <form name="gallatin">
-     <page number="1">
-       <field>
-
-         <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>instructor</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Instructor</label>
-         <input-type>name</input-type>
-
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the names of the instructor of this course.*Required*&lt;/em&gt;</hint>
-         <required>You must enter an instructor name for this course.</required>
-       </field>
-
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Course Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the  title of the course. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a title for this course.</required>
-
-       </field>
-
-          <field>
-         <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>coursenumber</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Course Number</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the number of this course.*Required*&lt;/em&gt;</hint>
-         <required>You must enter the course number</required>
-       </field>
-
-
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>semester</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Term</label>
-         <input-type>semester</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the semester of this course.*Required*&lt;/em&gt;</hint>
-         <required>You must enter the semester</required>
-       </field>
-
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Keywords</label>
-         <input-type>onebox</input-type>
-
-         <hint></hint>
-         <required></required>
-       </field>
-        
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>topic</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Subject Area</label>
-         <input-type value-pairs-name="gallatin_subjects">dropdown</input-type>
-
-         <hint></hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-   <form name="DataS">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Creator</label>
-                 <input-type>name</input-type>
-
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of Issue</label>
-         <input-type>date</input-type>
-         <hint>Please give the date of previous publication or public distribution
-                        below.  You can leave out the day and/or month if they aren't
-                        applicable.</hint>
-
-         <required>You must enter at least the year.</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofseries</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Series</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the title of the series this item is part of.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>OCLC Number</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-
-         <required></required>
-       </field>
-
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter description of the item below. </hint>
-         <required></required>
-       </field>
-
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>description</dc-element>
-         <dc-qualifier>additional</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Additional Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>format</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Format</label>
-         <input-type>onebox</input-type>
-         <hint> Enter information on item's format in this box. </hint>
-         <required></required>
-       </field>
-      
+  <!-- submission forms.Each separate form set has a unique name as an      -->
+
+  <!-- attribute. This name matches one of the names in the form-map. One   -->
+  <!-- named form set has the name "traditional"; as this name suggests,    -->
+  <!-- it is the old style and is also the default, which gets used when    -->
+  <!-- the specified collection has no correspondingly named form set.      -->
+  <!--                                                                      -->
+  <!-- Each form set contains an ordered set of pages; each page defines    -->
+  <!-- one submission metadata entry screen. Each page has an ordered list  -->
+  <!-- of field definitions, Each field definition corresponds to one       -->
+  <!-- metatdata entry (a so-called row), which has a DC element name, a    -->
+
+  <!-- displayed label, a text string prompt which is called a hint , and   -->
+  <!-- an input-type. Each field also may hold optional elements: DC        -->
+  <!-- qualifier name, a repeatable flag, and a text string whose presence  -->
+  <!-- serves as a 'this field is required' flag.                           -->
+  <form-definitions>
+
+    <form name="traditional">
+      <page number="1">
         <field>
 
-                 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-
-         <hint>Select the language of the main content of the item.  If the lang
-uage does not appear in the list below, please select 'Other'.  If the content d
-oes not really have a language (for example, if it is a dataset or an image) ple
-ase select 'N/A'.</hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>coverage</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Coverage</label>
-         <input-type>onebox</input-type>
-         <hint> Enter information on item's coverage in this box. </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>source</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Source</label>
-         <input-type>onebox</input-type>
-         <hint> Enter information on item's source in this box. </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Relation</label>
-         <input-type>onebox</input-type>
-         <hint> Enter information on item's relation in this box. </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>other</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Contributor</label>
-         <input-type>onebox</input-type>
-         <hint> Enter information on item's contributor in this box. </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>coverage</dc-element>
-         <dc-qualifier>temporal</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Date</label>
-         <input-type>date</input-type>
-         <hint> Enter Date below </hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier>resource</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Resource Type</label>
-         <input-type>onebox</input-type>
-         <hint> Enter resource type in the box below </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-
-   <form name="Aruna1">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
-
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Issue Date</label>
-         <input-type>date</input-type>
-         <hint>Please give the date of previous publication or public distribution
-                        below.  You can leave out the day and/or month if they aren't
-                        applicable.</hint>
-
-         <required>You must enter at least the year.</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier>place</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Place of Publication</label>
-         <input-type>onebox</input-type>
-         <hint></hint>
-         <required></required>
-       </field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must  add at least one author</required>
+        </field>
 
         <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>coverage</dc-element>
-         <dc-qualifier>spatial</dc-qualifier>
-
-         <repeatable>true</repeatable>
-         <label>Geographic Coverage</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the geographic information related to the recording.</hint>
-         <required></required>
-       </field>
-
-        <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Citation</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>uri</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Related Resources</label>
-         <input-type>onebox</input-type>
-         <hint></hint>
-         <required></required>
-       </field>
-  
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-
-     </page>
-   </form>
-   <form name="Aruna">
-     <page number="1">
-       <field>
-
-                 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
-
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>OCLC Number(Citation)</label>
-         <input-type>onebox</input-type>
-         <hint> link to the OCLC WorldCat page </hint>
-         <required></required>
-       </field>
-       <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of Issue</label>
-         <input-type>date</input-type>
-         <hint>Please give the date of previous publication or public distributi
-on
-                        below.  You can leave out the day and/or month if they a
-ren't
-                        applicable.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-            <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-       </field>
-           <field>
-
-                 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-<form name="Stern">
-     <page number="1">
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Authors</label>
-                 <input-type>name</input-type>
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-
-         <required>You must enter a main title for this item.</required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier>alternative</dc-qualifier>
-
-         <repeatable>true</repeatable>
-         <label>Other Titles</label>
-         <input-type>onebox</input-type>
-         <hint>If the item has any alternative titles, please enter them below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of Issue</label>
-
-         <input-type>date</input-type>
-         <hint>Please give the date of previous publication or public distribution
-                        below.  You can leave out the day and/or month if they aren't
-                        applicable.</hint>
-         <required>You must enter at least the year.</required>
-       </field>
-       <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the instance of this item.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>publisher</dc-element>
-         <dc-qualifier>name</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Journal Name</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the instance of this item.</hint>
-
-         <required></required>
-       </field>
-
- <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>publisher</dc-element>
-         <dc-qualifier>ISSN</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Journal ISSN</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the ISSN of the publisher of the previously issued instance
- of this item.</hint>
-
-         <required></required>
-       </field>
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>DOI</dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-
-         <repeatable>true</repeatable>
-         <label>Digital Object ID</label>
-         <input-type>onebox</input-type>
-         <hint>  please enter the article DOI</hint>
-         <required></required>
-
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Citation</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofseries</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Series/Report No.</label>
-         <input-type>series</input-type>
-         <hint>Enter the series and number assigned to this item by your community.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down
-the "CTRL" or "Shift" key.</hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select '
-Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-
-       </field>
-   <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>authorid-ssrn</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>AuthorID</label>
-
-        <input-type value-pairs-name="authors_identifiers">dropdown</input-type>
-         <hint>Select the author identifier.
-         Only numeric value will be stored in the database</hint>
-         <required></required>
-       </field>
-   <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>paperid-ssrn</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>PaperID</label>
-        <input-type >onebox</input-type>
-         <hint>Enter a paper ID </hint>
-         <required></required>
-       </field>
-
-     <!--commented by Kate-->
-     <!--commented by Kate-->
-     <!--</page>
-
-     <page number="2">-->
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>abstract</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Abstract</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the abstract of the item below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-
-                 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>sponsorship</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Sponsors</label>
-         <input-type>textarea</input-type>
-
-         <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-         <required></required>
-
-       </field>
-       <field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Rights</label>
-
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-   <form name="Collins">
-
-     <page number="1">
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Linguist</label>
-
-                 <input-type>name</input-type>
-         <hint>Enter the names of the linguist(s) for this class session.</hint>
-         <required>You must enter a name here.</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the title in form "Course Name YYYY-MM-DD" (date of recording). *Required*&lt;/em&gt;</hint>
-
-         <required>You must enter a main title for this item.</required>
-       </field>
-       
-        <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>transcriber</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Transcriber</label>
-                 <input-type>name</input-type>
-         <hint>Enter the names of the person taking notes that day.</hint>
-         <required>You must enter a name here.</required>
-       </field>
-       
-              
-        <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>recorder</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Recorder</label>
-                 <input-type>name</input-type>
-         <hint>Enter the name of the person recording that day.</hint>
-
-         <required>You must enter a name here.</required>
-       </field>
-       
-              
-        <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>informant</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Informant</label>
-                 <input-type>name</input-type>
-         <hint>Enter the name(s) of the informant.</hint>
-         <required></required>
-       </field>
-
-
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date added to archive</label>
-         <input-type>date</input-type>
-
-         <hint></hint>
-         <required>You must enter at least the year.</required>
-       </field>
-       
-        <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>date</dc-element>
-         <dc-qualifier>created</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Date of creation</label>
-         <input-type>date</input-type>
-         <hint>Enter date that recording was made.</hint>
-         <required>You must enter at least the year.</required>
-       </field>
-
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-
-         <required>You must enter the types of item (recording, oral; document)</required>
-       </field>
-       
-              <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type>onebox</input-type>
-
-         <hint>The language of the main content of the item.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="collins_languages">dropdown</input-type>
-         <hint>The iso code for the language of the main content of the item.</hint>
-         <required></required>
-       </field>
-       
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>dialect</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Dialect</label>
-         <input-type>onebox</input-type>
-
-         <hint>Dialect information for the item, if any.</hint>
-         <required></required>
-       </field>
-       
-         <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>coverage</dc-element>
-         <dc-qualifier>spatial</dc-qualifier>
-
-         <repeatable>true</repeatable>
-         <label>Coverage,spatial</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the geographic information related to the recording.</hint>
-         <required>You must enter geographic information here.</required>
-       </field>
-
-       
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-         <required>You must enter subject terms for this item.</required>
-       </field>
-
-      
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-
-         <hint> Enter description or comments in this box, including any methodology notes and location of the recording session. </hint>
-         <required>You must enter a description here.</required>
-       </field>
-       
-       
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-
-         <dc-qualifier>equipment</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Equipment</label>
-         <input-type>textarea</input-type>
-         <hint> Details about the recording equipment. </hint>
-         <required></required>
-
-       </field>
-
- <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-
-         <dc-qualifier>location</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Location</label>
-         <input-type>textarea</input-type>
-         <hint> Enter location where recording was made. </hint>
-         <required></required>
-
-</field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Rights</label>
-
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-   <form name="Ramlila">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Author</label>
-                 <input-type>name</input-type>
-         <hint>Enter the names of the authors of this item below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier>alternative</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Description</label>
-         <input-type>onebox</input-type>
-         <hint></hint>
-         <required></required>
-       </field>
-
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofseries</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Lila</label>
-         <input-type value-pairs-name="lila_days">dropdown</input-type>
-         <hint>Enter the Day from 1 to 31</hint>
-         <required></required>
-       </field>
-<field>
-                 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>isbasedon</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Credits</label>
-         <input-type>onebox</input-type>
-         <hint></hint>
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>date</dc-element>
-         <dc-qualifier>created</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date</label>
-         <input-type >date</input-type>
-         <hint></hint>
-         <required></required>
-       </field>
-
-      <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-       </field>
-        
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>abstract</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Abstract</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the abstract of the item below. </hint>
-         <required></required>
-       </field>
-
-<field>
-<dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>location</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Location</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the abstract of the item below. </hint>
-         <required></required>
-       </field>
-
-
-<field>
-<dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Other</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-<form name="Laefer">
-     <page number="1">
-       <field>
-
-     <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
- <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
-         <required>You must  add at least one author</required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier>alternative</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Other Titles</label>
-         <input-type>onebox</input-type>
-         <hint>If the item has any alternative titles, please enter them below.</hint>
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of Issue</label>
-         <input-type>date</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
-                        below.  You can leave out the day and/or month if they aren't
-                        applicable. *Required*&lt;/em&gt;</hint>
-
-         <required>You must enter at least the year.</required>
-       </field>
-
-     <field>
-     <dc-schema>prism</dc-schema>
-         <dc-element>publicationName</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Journal Title</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the journal name of the previously issued instance of this item.</hint>
-         <required></required>
-    </field>
-
-    <field>
-     <dc-schema>prism</dc-schema>
-         <dc-element>volume</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Journal Volume</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the journal volume of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-    <field>
-     <dc-schema>prism</dc-schema>
-         <dc-element>issueIdentifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Journal Issue</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the journal issue of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-    <field>
-     <dc-schema>prism</dc-schema>
-         <dc-element>startingPage</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Start Page</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the journal start page of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-    <field>
-     <dc-schema>prism</dc-schema>
-         <dc-element>endingPage</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>End Page</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the journal end page of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Publisher</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
-         <required></required>
-       </field>
-
-     <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofconference</dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Conference Title</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the conference name of the previously issued instance of this item.</hint>
-         <required></required>
-    </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartofseries</dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Series/Report No.</label>
-         <input-type>series</input-type>
-         <hint>Enter the series and number assigned to this item by your community.</hint>
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Identifiers</label>
-         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-         <hint>If the item has any identification numbers or codes associated with
-it, please enter the types and the actual numbers or codes below.</hint>
-
-         <required></required>
-       </field>
-       
-       <field>
-     <dc-schema>dc</dc-schema>
-
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>citation</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Citation</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for the previously issued instance of this item.</hint>
-
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>true</repeatable>
-
-         <label>Type</label>
-         <input-type value-pairs-name="common_types">dropdown</input-type>
-         <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
-         <required></required>
-       </field>
-
-      <field>
-
-     <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-       </field>
-        
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
-
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>abstract</dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Abstract</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the abstract of the item below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>sponsorship</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Sponsors</label>
-
-         <input-type>textarea</input-type>
-         <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
-         <required></required>
-       </field>
-
-       <field>
-     <dc-schema>dc</dc-schema>
-
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any other description or comments in this box. </hint>
-
-         <required></required>
-       </field>
-       <field>
-     <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-     </page>
-   </form>
-<form name="Jones">
-     <page number="1">
-       <field>
-
-		 <dc-schema>dc</dc-schema>
-         <dc-element>contributor</dc-element>
-         <dc-qualifier>author</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Authors</label>
-                 <input-type>name</input-type>
- <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
-         <required>You must add at least one author</required>
-       </field>
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
-
-         <repeatable>false</repeatable>
-         <label>Title / Description of the object</label>
-         <input-type>onebox</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
-         <required>You must enter a main title for this item.</required>
-
-       </field>
-
-
-       
-       <field>
-		 <dc-schema>dc</dc-schema>de
-         <dc-element>date</dc-element>
-         <dc-qualifier>issued</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of digital object</label>
-         <input-type>date</input-type>
-         <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date for public distribution in the FDA. * The date that the digital file was uploaded. *&lt;/em&gt;</hint>
-         <required>You must enter at least the year.</required>
-       </field>
-
-      <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>date</dc-element>
-         <dc-qualifier>created</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Date of object depicted</label>
-         <input-type>date</input-type>
-         <input-type>onebox</input-type>
-         <hint>Please enter the date or estimate data range for the object depicted. </hint>
-       </field>
-    
-     
-
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier>other</dc-qualifier>
-                  <repeatable>true</repeatable>
-         <label>Technical designation of object</label>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
           <input-type>onebox</input-type>
-         <hint>Please enter any identification numbers or codes associated with the object depicted (i.e. museum or site, inventory number).</hint>
-         <required></required>
-       </field>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
 
-   <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>provenance</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Provenance</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the provenance of the object depicted.</hint>
-         <required></required>
-       </field>
+        </field>
 
-      
-     <field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+          <repeatable>true</repeatable>
 
-		 <dc-schema>dc</dc-schema>
-         <dc-element>language</dc-element>
-         <dc-qualifier>iso</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Language</label>
-         <input-type value-pairs-name="jones_languages">dropdown</input-type>
+          <label>Other Titles</label>
+          <input-type>onebox</input-type>
+          <hint>If the item has any alternative titles, please enter them below.</hint>
+          <required></required>
+        </field>
 
-         <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
-         <required></required>
-       </field>
+        <field>
+          <dc-schema>dc</dc-schema>
 
-  <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>subject</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <!-- An input-type of twobox MUST be marked as repeatable -->
-         <repeatable>true</repeatable>
-         <label>Subject Keywords</label>
-         <input-type>onebox</input-type>
-         <hint> Enter appropriate subject keywords or phrases below. </hint>
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable. *Required*&lt;/em&gt;</hint>
 
-         <required></required>
-         <vocabulary>srsc</vocabulary>
-       </field>
+          <required>You must enter at least the year.</required>
+        </field>
 
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Description of particular view</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the description of the particular view depicted below. </hint>
-         <required></required>
-       </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Series/Report No.</label>
+          <input-type>series</input-type>
+          <hint>Enter the series and number assigned to this item by your community.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>sponsorship</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Sponsors</label>
+
+          <input-type>textarea</input-type>
+          <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Tandon">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must  add at least one author</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Other Titles</label>
+          <input-type>onebox</input-type>
+          <hint>If the item has any alternative titles, please enter them below.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable. *Required*&lt;/em&gt;</hint>
+          <required>You must enter at least the year.</required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>DOI</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>DOI</label>
+          <input-type>onebox</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>firstPage</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>First page</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the first page of the article below. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>lastPage</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Last Page</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the last page of the article below. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required>You must enter the types of item (recording, oral; document)</required>
+        </field>
+      </page>
+    </form>
+    <form name="Relics">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must  add at least one author</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable. *Required*&lt;/em&gt;</hint>
+
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Type</label>
+          <input-type>onebox</input-type>
+          <hint> Enter the type of the resource </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter description of the item below. </hint>
+          <required></required>
+        </field>
 
 
-   <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>format</dc-element>
-         <dc-qualifier>mimetype</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>File format</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the file format type of the digital object. </hint>
-         <required></required>
-       </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>coverage</dc-element>
+          <dc-qualifier>spatial</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Country</label>
+          <input-type value-pairs-name="relics_countries">dropdown</input-type>
+          <hint> Select the name of the country from the list below </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>source</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Source</label>
+
+          <input-type>onebox</input-type>
+          <hint> Enter the names of the source </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+
+      </page>
+    </form>
+    <form name="therapy">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Issue Date</label>
+          <input-type>date</input-type>
+          <hint> </hint>
+
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+
+          <hint></hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>category</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Category</label>
+          <input-type value-pairs-name="music_subjects">dropdown</input-type>
+          <hint>Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key</hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="gallatin">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>instructor</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Instructor</label>
+          <input-type>name</input-type>
+
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the names of the instructor of this course.*Required*&lt;/em&gt;</hint>
+          <required>You must enter an instructor name for this course.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Course Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the  title of the course. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a title for this course.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>coursenumber</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Course Number</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the number of this course.*Required*&lt;/em&gt;</hint>
+          <required>You must enter the course number</required>
+        </field>
 
 
-      <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>equipment</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Technical specifications</label>
-         <input-type>textarea</input-type>
-         <hint> Enter the description of how the digital object was generated below (camera model, file formats of photos used, fitting software used). </hint>
-         <required></required>
-       </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>semester</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Term</label>
+          <input-type>semester</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the semester of this course.*Required*&lt;/em&gt;</hint>
+          <required>You must enter the semester</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Keywords</label>
+          <input-type>onebox</input-type>
+
+          <hint></hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>topic</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Subject Area</label>
+          <input-type value-pairs-name="gallatin_subjects">dropdown</input-type>
+
+          <hint></hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="DataS">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Creator</label>
+          <input-type>name</input-type>
+
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable.</hint>
+
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Series</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the title of the series this item is part of.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>OCLC Number</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+
+          <required></required>
+        </field>
 
 
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>description</dc-element>
-         <dc-qualifier>additional</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Additional description</label>
-         <input-type>textarea</input-type>
-         <hint> Enter any additional description or comments in this box. </hint>
-         <required></required>
-       </field>
+        <field>
+          <dc-schema>dc</dc-schema>
 
-       <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>rights</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Rights</label>
-         <input-type>textarea</input-type>
-         <hint> Enter information on item's rights in this box. </hint>
-         <required></required>
-       </field>
-    
-   <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>isreferencedby</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Bibliographic citation</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the standard citation for an article related to this item.</hint>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
 
-       </field>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter description of the item below. </hint>
+          <required></required>
+        </field>
 
 
-   <field>
-		 <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>uri</dc-qualifier>
-         <repeatable>false</repeatable>
-         <label>Citation link</label>
-         <input-type>onebox</input-type>
-         <hint>Enter the handle or persistent url for for an article related to this item.</hint>
+        <field>
+          <dc-schema>dc</dc-schema>
 
-       </field>
- </page>
-   </form>
-</form-definitions>
+          <dc-element>description</dc-element>
+          <dc-qualifier>additional</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Additional Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
 
- <!-- form-value-pairs populate dropdown and qualdrop-value lists.          -->
- <!-- The form-value-pairs element holds child elements named 'value-pairs' -->
- <!-- A 'value-pairs' element has a value-pairs-name and a dc-term          -->
- <!-- attribute. The dc-term attribute specifies which to which Dublin Core -->
- <!-- Term this set of value-pairs applies.                                 -->
- <!--     Current dc-terms are: identifier-pairs, type-pairs, and           -->
- <!--     language_iso-pairs. The name attribute matches a name             -->
- <!--     in the form-map, above.                                           -->
- <!-- A value-pair contains one 'pair' for each value displayed in the list -->
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
- <!-- Each pair contains a 'displayed-value' element and a 'stored-value'   -->
- <!-- element. A UI list displays the displayed-values, but the program     -->
- <!-- stores the associated stored-values in the database.                  -->
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>format</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
- <form-value-pairs>
-   <value-pairs value-pairs-name="common_identifiers" dc-term="identifier">
-     <pair>
-       <displayed-value>ISSN</displayed-value>
-       <stored-value>issn</stored-value>
+          <label>Format</label>
+          <input-type>onebox</input-type>
+          <hint> Enter information on item's format in this box. </hint>
+          <required></required>
+        </field>
+        
+        <field>
 
-     </pair>
-     <pair>
-       <displayed-value>Other</displayed-value>
-       <stored-value>other</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>ISMN</displayed-value>
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
 
-       <stored-value>ismn</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Gov't Doc #</displayed-value>
-       <stored-value>govdoc</stored-value>
-     </pair>
-     <pair>
+          <hint>Select the language of the main content of the item.  If the lang
+          uage does not appear in the list below, please select 'Other'.  If the content d
+          oes not really have a language (for example, if it is a dataset or an image) ple
+          ase select 'N/A'.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>coverage</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
-       <displayed-value>URI</displayed-value>
-       <stored-value>uri</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>ISBN</displayed-value>
-       <stored-value>isbn</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>DOI</displayed-value>
-       <stored-value>DOI</stored-value>
-     </pair>
+          <label>Coverage</label>
+          <input-type>onebox</input-type>
+          <hint> Enter information on item's coverage in this box. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>source</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
-   </value-pairs>
-   <value-pairs value-pairs-name="relics_countries" dc-term="coverage">
-         <pair>
-             <displayed-value>Argentina</displayed-value>
-             <stored-value>Argentina</stored-value>
+          <label>Source</label>
+          <input-type>onebox</input-type>
+          <hint> Enter information on item's source in this box. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
-         </pair>
-         <pair>
-             <displayed-value>Brazil</displayed-value>
-             <stored-value>Brazil</stored-value>
-         </pair>
-         <pair>
-             <displayed-value>Chile</displayed-value>
-             <stored-value>Chile</stored-value>
-         </pair>
-         <pair>
-             <displayed-value>Other</displayed-value>
-             <stored-value>Other</stored-value>
-         </pair>
-     </value-pairs>
-   <value-pairs value-pairs-name="music_subjects" dc-term="subject">
-     <pair>
-       <displayed-value>Adult</displayed-value>
-       <stored-value>adult</stored-value>
+          <label>Relation</label>
+          <input-type>onebox</input-type>
+          <hint> Enter information on item's relation in this box. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>other</dc-qualifier>
+          <repeatable>false</repeatable>
 
-     </pair>
-     <pair>
-       <displayed-value>Child</displayed-value>
-       <stored-value>child</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Geriatric</displayed-value>
+          <label>Contributor</label>
+          <input-type>onebox</input-type>
+          <hint> Enter information on item's contributor in this box. </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>coverage</dc-element>
+          <dc-qualifier>temporal</dc-qualifier>
+          <repeatable>false</repeatable>
 
-       <stored-value>geriatric</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Theory</displayed-value>
-       <stored-value>theory</stored-value>
-     </pair>
-   </value-pairs>
-   <value-pairs value-pairs-name="music_types" dc-term="type">
-     <pair>
-       <displayed-value>Adult</displayed-value>
-       <stored-value>adult</stored-value>
-     </pair>
-   </value-pairs>
+          <label>Date</label>
+          <input-type>date</input-type>
+          <hint> Enter Date below </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier>resource</dc-qualifier>
+          <repeatable>false</repeatable>
 
-   <value-pairs value-pairs-name="common_types" dc-term="type">
-     <pair>
-       <displayed-value>Animation</displayed-value>
-       <stored-value>Animation</stored-value>
-     </pair>
-     <pair>
+          <label>Resource Type</label>
+          <input-type>onebox</input-type>
+          <hint> Enter resource type in the box below </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
 
-       <displayed-value>Article</displayed-value>
-       <stored-value>Article</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Book</displayed-value>
-       <stored-value>Book</stored-value>
-     </pair>
+    <form name="Aruna1">
+      <page number="1">
+        <field>
 
-     <pair>
-       <displayed-value>Book chapter</displayed-value>
-       <stored-value>Book chapter</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Dataset</displayed-value>
-       <stored-value>Dataset</stored-value>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
 
-     </pair>
-     <pair>
-       <displayed-value>Document</displayed-value>
-       <stored-value>Document</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Learning Object</displayed-value>
-       <stored-value>Learning Object</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Image</displayed-value>
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
 
-       <stored-value>Image</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Image, 3-D</displayed-value>
-       <stored-value>Image, 3-D</stored-value>
-     </pair>
-     <pair>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
 
-       <displayed-value>Map</displayed-value>
-       <stored-value>Map</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Musical Score</displayed-value>
-       <stored-value>Musical Score</stored-value>
-     </pair>
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
 
-     <pair>
-       <displayed-value>Plan or blueprint</displayed-value>
-       <stored-value>Plan or blueprint</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Preprint</displayed-value>
-       <stored-value>Preprint</stored-value>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
 
-     </pair>
-     <pair>
-       <displayed-value>Presentation</displayed-value>
-       <stored-value>Presentation</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Recording, acoustical</displayed-value>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
 
-       <stored-value>Recording, acoustical</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Recording, musical</displayed-value>
-       <stored-value>Recording, musical</stored-value>
-     </pair>
-     <pair>
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
 
-       <displayed-value>Recording, oral</displayed-value>
-       <stored-value>Recording, oral</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Software</displayed-value>
-       <stored-value>Software</stored-value>
-     </pair>
+        <field>
+          <dc-schema>dc</dc-schema>
 
-     <pair>
-       <displayed-value>Technical Report</displayed-value>
-       <stored-value>Technical Report</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Thesis</displayed-value>
-       <stored-value>Thesis</stored-value>
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Issue Date</label>
+          <input-type>date</input-type>
+          <hint>Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable.</hint>
 
-     </pair>
-     <pair>
-       <displayed-value>Video</displayed-value>
-       <stored-value>Video</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Working Paper</displayed-value>
+          <required>You must enter at least the year.</required>
+        </field>
 
-       <stored-value>Working Paper</stored-value>
-     </pair>
-     <pair>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
 
-       <displayed-value>Other</displayed-value>
-       <stored-value>Other</stored-value>
-     </pair>
-   </value-pairs>
-   <value-pairs value-pairs-name="music_lan" dc-term="language_iso">
-     <pair>
-       <displayed-value>English (United States)</displayed-value>
-       <stored-value>en_US</stored-value>
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier>place</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Place of Publication</label>
+          <input-type>onebox</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>coverage</dc-element>
+          <dc-qualifier>spatial</dc-qualifier>
+
+          <repeatable>true</repeatable>
+          <label>Geographic Coverage</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the geographic information related to the recording.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>uri</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Related Resources</label>
+          <input-type>onebox</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+
+      </page>
+    </form>
+    <form name="Aruna">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>OCLC Number(Citation)</label>
+          <input-type>onebox</input-type>
+          <hint> link to the OCLC WorldCat page </hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>Please give the date of previous publication or public distributi
+          on
+          below.  You can leave out the day and/or month if they a
+          ren't
+          applicable.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+        </field>
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Stern">
+      <page number="1">
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+
+          <required>You must enter a main title for this item.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+
+          <repeatable>true</repeatable>
+          <label>Other Titles</label>
+          <input-type>onebox</input-type>
+          <hint>If the item has any alternative titles, please enter them below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+
+          <input-type>date</input-type>
+          <hint>Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable.</hint>
+          <required>You must enter at least the year.</required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>publisher</dc-element>
+          <dc-qualifier>name</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Journal Name</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>publisher</dc-element>
+          <dc-qualifier>ISSN</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Journal ISSN</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the ISSN of the publisher of the previously issued instance
+          of this item.</hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>DOI</dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+
+          <repeatable>true</repeatable>
+          <label>Digital Object ID</label>
+          <input-type>onebox</input-type>
+          <hint>  please enter the article DOI</hint>
+          <required></required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Series/Report No.</label>
+          <input-type>series</input-type>
+          <hint>Enter the series and number assigned to this item by your community.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down
+          the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select '
+          Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>authorid-ssrn</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>AuthorID</label>
+
+          <input-type value-pairs-name="authors_identifiers">dropdown</input-type>
+          <hint>Select the author identifier.
+          Only numeric value will be stored in the database</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>paperid-ssrn</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>PaperID</label>
+          <input-type >onebox</input-type>
+          <hint>Enter a paper ID </hint>
+          <required></required>
+        </field>
+
+        <!--commented by Kate-->
+        <!--commented by Kate-->
+        <!--</page>
+
+<page number="2">-->
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>sponsorship</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Sponsors</label>
+          <input-type>textarea</input-type>
+
+          <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+          <required></required>
+
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Rights</label>
+
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Collins">
+
+      <page number="1">
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Linguist</label>
+
+          <input-type>name</input-type>
+          <hint>Enter the names of the linguist(s) for this class session.</hint>
+          <required>You must enter a name here.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the title in form "Course Name YYYY-MM-DD" (date of recording). *Required*&lt;/em&gt;</hint>
+
+          <required>You must enter a main title for this item.</required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>transcriber</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Transcriber</label>
+          <input-type>name</input-type>
+          <hint>Enter the names of the person taking notes that day.</hint>
+          <required>You must enter a name here.</required>
+        </field>
+        
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>recorder</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Recorder</label>
+          <input-type>name</input-type>
+          <hint>Enter the name of the person recording that day.</hint>
+
+          <required>You must enter a name here.</required>
+        </field>
+        
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>informant</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Informant</label>
+          <input-type>name</input-type>
+          <hint>Enter the name(s) of the informant.</hint>
+          <required></required>
+        </field>
+
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date added to archive</label>
+          <input-type>date</input-type>
+
+          <hint></hint>
+          <required>You must enter at least the year.</required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>created</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Date of creation</label>
+          <input-type>date</input-type>
+          <hint>Enter date that recording was made.</hint>
+          <required>You must enter at least the year.</required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+
+          <required>You must enter the types of item (recording, oral; document)</required>
+        </field>
+        
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type>onebox</input-type>
+
+          <hint>The language of the main content of the item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="collins_languages">dropdown</input-type>
+          <hint>The iso code for the language of the main content of the item.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>dialect</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Dialect</label>
+          <input-type>onebox</input-type>
+
+          <hint>Dialect information for the item, if any.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>coverage</dc-element>
+          <dc-qualifier>spatial</dc-qualifier>
+
+          <repeatable>true</repeatable>
+          <label>Coverage,spatial</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the geographic information related to the recording.</hint>
+          <required>You must enter geographic information here.</required>
+        </field>
+
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+          <required>You must enter subject terms for this item.</required>
+        </field>
+
+        
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+
+          <hint> Enter description or comments in this box, including any methodology notes and location of the recording session. </hint>
+          <required>You must enter a description here.</required>
+        </field>
+        
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+
+          <dc-qualifier>equipment</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Equipment</label>
+          <input-type>textarea</input-type>
+          <hint> Details about the recording equipment. </hint>
+          <required></required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+
+          <dc-qualifier>location</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Location</label>
+          <input-type>textarea</input-type>
+          <hint> Enter location where recording was made. </hint>
+          <required></required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Rights</label>
+
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Ramlila">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Author</label>
+          <input-type>name</input-type>
+          <hint>Enter the names of the authors of this item below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Description</label>
+          <input-type>onebox</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Lila</label>
+          <input-type value-pairs-name="lila_days">dropdown</input-type>
+          <hint>Enter the Day from 1 to 31</hint>
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>isbasedon</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Credits</label>
+          <input-type>onebox</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>created</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date</label>
+          <input-type >date</input-type>
+          <hint></hint>
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>location</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Location</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Other</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Laefer">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must  add at least one author</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier>alternative</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Other Titles</label>
+          <input-type>onebox</input-type>
+          <hint>If the item has any alternative titles, please enter them below.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of Issue</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date of previous publication or public distribution
+          below.  You can leave out the day and/or month if they aren't
+          applicable. *Required*&lt;/em&gt;</hint>
+
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+          <dc-schema>prism</dc-schema>
+          <dc-element>publicationName</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Journal Title</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the journal name of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>prism</dc-schema>
+          <dc-element>volume</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Journal Volume</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the journal volume of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>prism</dc-schema>
+          <dc-element>issueIdentifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Journal Issue</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the journal issue of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>prism</dc-schema>
+          <dc-element>startingPage</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Start Page</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the journal start page of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>prism</dc-schema>
+          <dc-element>endingPage</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>End Page</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the journal end page of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>publisher</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Publisher</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofconference</dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Conference Title</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the conference name of the previously issued instance of this item.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>ispartofseries</dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Series/Report No.</label>
+          <input-type>series</input-type>
+          <hint>Enter the series and number assigned to this item by your community.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Identifiers</label>
+          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+          <hint>If the item has any identification numbers or codes associated with
+          it, please enter the types and the actual numbers or codes below.</hint>
+
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>citation</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>type</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>true</repeatable>
+
+          <label>Type</label>
+          <input-type value-pairs-name="common_types">dropdown</input-type>
+          <hint> Select the type(s) of content you are submitting. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+          <required></required>
+        </field>
+
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'.  If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>abstract</dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Abstract</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the abstract of the item below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>sponsorship</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Sponsors</label>
+
+          <input-type>textarea</input-type>
+          <hint> Enter the names of any sponsors and/or funding codes in the box below. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any other description or comments in this box. </hint>
+
+          <required></required>
+        </field>
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+      </page>
+    </form>
+    <form name="Jones">
+      <page number="1">
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>contributor</dc-element>
+          <dc-qualifier>author</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Authors</label>
+          <input-type>name</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter at least one author. *Required*&lt;/em&gt;</hint>
+          <required>You must add at least one author</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>title</dc-element>
+          <dc-qualifier></dc-qualifier>
+
+          <repeatable>false</repeatable>
+          <label>Title / Description of the object</label>
+          <input-type>onebox</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Enter the main title of the item. *Required*&lt;/em&gt;</hint>
+          <required>You must enter a main title for this item.</required>
+
+        </field>
+
+
+        
+        <field>
+          <dc-schema>dc</dc-schema>de
+          <dc-element>date</dc-element>
+          <dc-qualifier>issued</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of digital object</label>
+          <input-type>date</input-type>
+          <hint>&lt;em class="submitFormHelpRequired"&gt;Please give the date for public distribution in the FDA. * The date that the digital file was uploaded. *&lt;/em&gt;</hint>
+          <required>You must enter at least the year.</required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>date</dc-element>
+          <dc-qualifier>created</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Date of object depicted</label>
+          <input-type>date</input-type>
+          <input-type>onebox</input-type>
+          <hint>Please enter the date or estimate data range for the object depicted. </hint>
+        </field>
+        
+        
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>identifier</dc-element>
+          <dc-qualifier>other</dc-qualifier>
+          <repeatable>true</repeatable>
+          <label>Technical designation of object</label>
+          <input-type>onebox</input-type>
+          <hint>Please enter any identification numbers or codes associated with the object depicted (i.e. museum or site, inventory number).</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>provenance</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Provenance</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the provenance of the object depicted.</hint>
+          <required></required>
+        </field>
+
+        
+        <field>
+
+          <dc-schema>dc</dc-schema>
+          <dc-element>language</dc-element>
+          <dc-qualifier>iso</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Language</label>
+          <input-type value-pairs-name="jones_languages">dropdown</input-type>
+
+          <hint>Select the language of the main content of the item.  If the language does not appear in the list below, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select 'N/A'.</hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>subject</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <!-- An input-type of twobox MUST be marked as repeatable -->
+          <repeatable>true</repeatable>
+          <label>Subject Keywords</label>
+          <input-type>onebox</input-type>
+          <hint> Enter appropriate subject keywords or phrases below. </hint>
+
+          <required></required>
+          <vocabulary>srsc</vocabulary>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Description of particular view</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the description of the particular view depicted below. </hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>format</dc-element>
+          <dc-qualifier>mimetype</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>File format</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the file format type of the digital object. </hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>equipment</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Technical specifications</label>
+          <input-type>textarea</input-type>
+          <hint> Enter the description of how the digital object was generated below (camera model, file formats of photos used, fitting software used). </hint>
+          <required></required>
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>description</dc-element>
+          <dc-qualifier>additional</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Additional description</label>
+          <input-type>textarea</input-type>
+          <hint> Enter any additional description or comments in this box. </hint>
+          <required></required>
+        </field>
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>rights</dc-element>
+          <dc-qualifier></dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Rights</label>
+          <input-type>textarea</input-type>
+          <hint> Enter information on item's rights in this box. </hint>
+          <required></required>
+        </field>
+        
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>isreferencedby</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Bibliographic citation</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the standard citation for an article related to this item.</hint>
+
+        </field>
+
+
+        <field>
+          <dc-schema>dc</dc-schema>
+          <dc-element>relation</dc-element>
+          <dc-qualifier>uri</dc-qualifier>
+          <repeatable>false</repeatable>
+          <label>Citation link</label>
+          <input-type>onebox</input-type>
+          <hint>Enter the handle or persistent url for for an article related to this item.</hint>
+
+        </field>
+      </page>
+    </form>
+  </form-definitions>
+
+  <!-- form-value-pairs populate dropdown and qualdrop-value lists.          -->
+  <!-- The form-value-pairs element holds child elements named 'value-pairs' -->
+  <!-- A 'value-pairs' element has a value-pairs-name and a dc-term          -->
+  <!-- attribute. The dc-term attribute specifies which to which Dublin Core -->
+  <!-- Term this set of value-pairs applies.                                 -->
+  <!--     Current dc-terms are: identifier-pairs, type-pairs, and           -->
+  <!--     language_iso-pairs. The name attribute matches a name             -->
+  <!--     in the form-map, above.                                           -->
+  <!-- A value-pair contains one 'pair' for each value displayed in the list -->
+
+  <!-- Each pair contains a 'displayed-value' element and a 'stored-value'   -->
+  <!-- element. A UI list displays the displayed-values, but the program     -->
+  <!-- stores the associated stored-values in the database.                  -->
+
+  <form-value-pairs>
+    <value-pairs value-pairs-name="common_identifiers" dc-term="identifier">
+      <pair>
+        <displayed-value>ISSN</displayed-value>
+        <stored-value>issn</stored-value>
+
+      </pair>
+      <pair>
+        <displayed-value>Other</displayed-value>
+        <stored-value>other</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>ISMN</displayed-value>
+
+        <stored-value>ismn</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Gov't Doc #</displayed-value>
+        <stored-value>govdoc</stored-value>
+      </pair>
+      <pair>
+
+        <displayed-value>URI</displayed-value>
+        <stored-value>uri</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>ISBN</displayed-value>
+        <stored-value>isbn</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>DOI</displayed-value>
+        <stored-value>DOI</stored-value>
+      </pair>
+
+    </value-pairs>
+    <value-pairs value-pairs-name="relics_countries" dc-term="coverage">
+      <pair>
+        <displayed-value>Argentina</displayed-value>
+        <stored-value>Argentina</stored-value>
+
+      </pair>
+      <pair>
+        <displayed-value>Brazil</displayed-value>
+        <stored-value>Brazil</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Chile</displayed-value>
+        <stored-value>Chile</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Other</displayed-value>
+        <stored-value>Other</stored-value>
       </pair>
     </value-pairs>
-   <!-- default language order: (from dspace 1.2.1)
-        "en_US", "en", "es", "de", "fr", "it", "ja", "zh", "other", ""
-     -->
-   <value-pairs value-pairs-name="common_iso_languages" dc-term="language_iso">
-     <pair>
-       <displayed-value>N/A</displayed-value>
-       <stored-value></stored-value>
-     </pair>
-     <pair>
-       <displayed-value>English (United States)</displayed-value>
-       <stored-value>en_US</stored-value>
+    <value-pairs value-pairs-name="music_subjects" dc-term="subject">
+      <pair>
+        <displayed-value>Adult</displayed-value>
+        <stored-value>adult</stored-value>
+
       </pair>
-     <pair>
-       <displayed-value>English</displayed-value>
-       <stored-value>en</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Spanish</displayed-value>
-       <stored-value>es</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>German</displayed-value>
-       <stored-value>de</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>French</displayed-value>
-       <stored-value>fr</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Italian</displayed-value>
-       <stored-value>it</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Japanese</displayed-value>
-       <stored-value>ja</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Chinese</displayed-value>
-       <stored-value>zh</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>(Other)</displayed-value>
-       <stored-value>other</stored-value>
-     </pair>
-      </value-pairs>
-     <value-pairs value-pairs-name="collins_languages" dc-term="language_iso">
-        <pair>
-       <displayed-value>mls</displayed-value>
-       <stored-value>mls</stored-value>
-     </pair>
-   </value-pairs>
-<value-pairs value-pairs-name="authors_identifiers" dc-term="authorid-ssrn">
-<pair><displayed-value>Aaker, Jennifer Lynn</displayed-value><stored-value>105813</stored-value></pair>
-<pair><displayed-value>Abbatello, Tara</displayed-value><stored-value>331649</stored-value></pair>
-
-<pair><displayed-value>Aboody, David</displayed-value><stored-value>62902</stored-value></pair>
-<pair><displayed-value>Acemoglu, Daron</displayed-value><stored-value>18621</stored-value></pair>
-<pair><displayed-value>Acharya, Viral V.</displayed-value><stored-value>142715</stored-value></pair>
-<pair><displayed-value>Ackerberg, Daniel A.</displayed-value><stored-value>269402</stored-value></pair>
-<pair><displayed-value>Acquisti, Alessandro</displayed-value><stored-value>57339</stored-value></pair>
-<pair><displayed-value>Adams, Ren√àe B.</displayed-value><stored-value>248065</stored-value></pair>
-
-<pair><displayed-value>Adler, Barry E.</displayed-value><stored-value>23066</stored-value></pair>
-<pair><displayed-value>Adomavicius, Gediminas</displayed-value><stored-value>1131949</stored-value></pair>
-<pair><displayed-value>Aerts, Marc</displayed-value><stored-value>1147166</stored-value></pair>
-<pair><displayed-value>Affleck-Graves, John Felix</displayed-value><stored-value>2122</stored-value></pair>
-<pair><displayed-value>Agarwal, Deepak</displayed-value><stored-value>593437</stored-value></pair>
-<pair><displayed-value>Agarwal, Sumit</displayed-value><stored-value>352406</stored-value></pair>
-
-<pair><displayed-value>Aggarwal, Rohit</displayed-value><stored-value>735974</stored-value></pair>
-<pair><displayed-value>Agichtein, Eugene</displayed-value><stored-value>1131962</stored-value></pair>
-<pair><displayed-value>Agrawal, Ashwini K.</displayed-value><stored-value>1126912</stored-value></pair>
-<pair><displayed-value>Agrawal, Deepak NMI2</displayed-value><stored-value>328668</stored-value></pair>
-<pair><displayed-value>Agrawal, Deepak</displayed-value><stored-value>1148837</stored-value></pair>
-<pair><displayed-value>Agrawal, Nidhi</displayed-value><stored-value>699395</stored-value></pair>
-
-<pair><displayed-value>Ahituv, Niv</displayed-value><stored-value>350466</stored-value></pair>
-<pair><displayed-value>Ahn, Dong-Hyun</displayed-value><stored-value>32563</stored-value></pair>
-<pair><displayed-value>Aiello, Cecilia H.</displayed-value><stored-value>753575</stored-value></pair>
-<pair><displayed-value>Akhavein, Jalal D.</displayed-value><stored-value>16933</stored-value></pair>
-<pair><displayed-value>Alan Bear, Larry</displayed-value><stored-value>1152957</stored-value></pair>
-<pair><displayed-value>Alcacer, Juan</displayed-value><stored-value>269573</stored-value></pair>
-
-<pair><displayed-value>Ali, Ashiq</displayed-value><stored-value>59239</stored-value></pair>
-<pair><displayed-value>Allan, Eberhart</displayed-value><stored-value>1151898</stored-value></pair>
-<pair><displayed-value>Allayannis, George S.</displayed-value><stored-value>138499</stored-value></pair>
-<pair><displayed-value>Allen, Franklin</displayed-value><stored-value>16888</stored-value></pair>
-<pair><displayed-value>Allen, Linda</displayed-value><stored-value>879</stored-value></pair>
-<pair><displayed-value>Allen, William T.</displayed-value><stored-value>97908</stored-value></pair>
-
-<pair><displayed-value>Almeid, Heitor</displayed-value><stored-value>1149003</stored-value></pair>
-<pair><displayed-value>Almeida, Heitor</displayed-value><stored-value>49859</stored-value></pair>
-<pair><displayed-value>Altman, Edward I.</displayed-value><stored-value>17593</stored-value></pair>
-<pair><displayed-value>Amador, Manuel</displayed-value><stored-value>93747</stored-value></pair>
-<pair><displayed-value>Amihud, Yakov</displayed-value><stored-value>17595</stored-value></pair>
-<pair><displayed-value>Amir, Eli</displayed-value><stored-value>16087</stored-value></pair>
-
-<pair><displayed-value>Amit, Eli</displayed-value><stored-value>1131109</stored-value></pair>
-<pair><displayed-value>Ammer, John Matthew</displayed-value><stored-value>16396</stored-value></pair>
-<pair><displayed-value>Anagnostakis, Kostas</displayed-value><stored-value>701836</stored-value></pair>
-<pair><displayed-value>Andersen, Torben G.</displayed-value><stored-value>17696</stored-value></pair>
-<pair><displayed-value>Anderson, Lanie</displayed-value><stored-value>359140</stored-value></pair>
-<pair><displayed-value>Anderson, Richard G.</displayed-value><stored-value>347475</stored-value></pair>
-
-<pair><displayed-value>Animesh, Animesh</displayed-value><stored-value>514966</stored-value></pair>
-<pair><displayed-value>Ansari, Asim</displayed-value><stored-value>1747</stored-value></pair>
-<pair><displayed-value>Ansari, Shahzad M.</displayed-value><stored-value>798534</stored-value></pair>
-<pair><displayed-value>Anthony, Saunders</displayed-value><stored-value>1149005</stored-value></pair>
-<pair><displayed-value>Arakawa, Kiyoshi</displayed-value><stored-value>680536</stored-value></pair>
-<pair><displayed-value>Aral, Sinan</displayed-value><stored-value>110270</stored-value></pair>
-
-<pair><displayed-value>Araman, Victor F.</displayed-value><stored-value>583956</stored-value></pair>
-<pair><displayed-value>Archak, Nikolay</displayed-value><stored-value>884454</stored-value></pair>
-<pair><displayed-value>Ariav, Gad</displayed-value><stored-value>350468</stored-value></pair>
-<pair><displayed-value>Arlen, Jennifer</displayed-value><stored-value>17334</stored-value></pair>
-<pair><displayed-value>Armony, Mor</displayed-value><stored-value>349603</stored-value></pair>
-<pair><displayed-value>Armstrong, J. Scott</displayed-value><stored-value>116288</stored-value></pair>
-
-<pair><displayed-value>Aron, Ravi</displayed-value><stored-value>1133974</stored-value></pair>
-<pair><displayed-value>Arora, Neeraj NMI1</displayed-value><stored-value>268782</stored-value></pair>
-<pair><displayed-value>Arrow, Kenneth J.</displayed-value><stored-value>93675</stored-value></pair>
-<pair><displayed-value>Arunkundram, Ravi</displayed-value><stored-value>1133793</stored-value></pair>
-<pair><displayed-value>Asker, Jhon</displayed-value><stored-value>1148137</stored-value></pair>
-<pair><displayed-value>Asker, John William</displayed-value><stored-value>245091</stored-value></pair>
-
-<pair><displayed-value>Assael, Henry</displayed-value><stored-value>713359</stored-value></pair>
-<pair><displayed-value>Asthana, Ajay</displayed-value><stored-value>1142954</stored-value></pair>
-<pair><displayed-value>Ater, Itai</displayed-value><stored-value>884203</stored-value></pair>
-<pair><displayed-value>Atkins, Susannah</displayed-value><stored-value>357853</stored-value></pair>
-<pair><displayed-value>Aue, Alexander</displayed-value><stored-value>1282745</stored-value></pair>
-<pair><displayed-value>Azoulay, Eddy</displayed-value><stored-value>1147159</stored-value></pair>
-
-<pair><displayed-value>B. Cabral, Luis M.</displayed-value><stored-value>1146523</stored-value></pair>
-<pair><displayed-value>Baccara, Mariagiovanna</displayed-value><stored-value>372674</stored-value></pair>
-<pair><displayed-value>Baccaraa, Mariagiovanna</displayed-value><stored-value>1133347</stored-value></pair>
-<pair><displayed-value>Back, Andrew D.</displayed-value><stored-value>1133792</stored-value></pair>
-<pair><displayed-value>Backus, David K.</displayed-value><stored-value>17597</stored-value></pair>
-<pair><displayed-value>Bagby, John W.</displayed-value><stored-value>86167</stored-value></pair>
-
-<pair><displayed-value>Bagchi, Rajesh</displayed-value><stored-value>665865</stored-value></pair>
-<pair><displayed-value>Baghai, Ramin</displayed-value><stored-value>452218</stored-value></pair>
-<pair><displayed-value>Bagozzi, Richard P.</displayed-value><stored-value>369606</stored-value></pair>
-<pair><displayed-value>Bailey, Elizabeth E.</displayed-value><stored-value>83338</stored-value></pair>
-<pair><displayed-value>Baily, Martin Neil</displayed-value><stored-value>99570</stored-value></pair>
-<pair><displayed-value>Baird, Irina M.</displayed-value><stored-value>664662</stored-value></pair>
-
-<pair><displayed-value>Baker, Malcolm P.</displayed-value><stored-value>167351</stored-value></pair>
-<pair><displayed-value>Bakos, Yannis</displayed-value><stored-value>70468</stored-value></pair>
-<pair><displayed-value>Balachandran, Kashi R.</displayed-value><stored-value>20870</stored-value></pair>
-<pair><displayed-value>Balakrishnan, Karthik</displayed-value><stored-value>734368</stored-value></pair>
-<pair><displayed-value>Balasubramanian, P. R.</displayed-value><stored-value>520447</stored-value></pair>
-<pair><displayed-value>Balasubramanian, Sridhar</displayed-value><stored-value>349523</stored-value></pair>
-
-<pair><displayed-value>Balasubramanian, V.</displayed-value><stored-value>1135951</stored-value></pair>
-<pair><displayed-value>Balduzzi, Pierluigi</displayed-value><stored-value>1359</stored-value></pair>
-<pair><displayed-value>Bali, Turan G.</displayed-value><stored-value>235620</stored-value></pair>
-<pair><displayed-value>Ball, Ray</displayed-value><stored-value>17468</stored-value></pair>
-<pair><displayed-value>Ballester, Marta</displayed-value><stored-value>1131117</stored-value></pair>
-<pair><displayed-value>Ballester Casado, Marta</displayed-value><stored-value>219754</stored-value></pair>
-
-<pair><displayed-value>Balsam, Steven</displayed-value><stored-value>28716</stored-value></pair>
-<pair><displayed-value>Bana, Gaurav</displayed-value><stored-value>413671</stored-value></pair>
-<pair><displayed-value>Bangia, Anil</displayed-value><stored-value>231769</stored-value></pair>
-<pair><displayed-value>Banker, Rajiv D.</displayed-value><stored-value>16797</stored-value></pair>
-<pair><displayed-value>Banks, Jeffrey</displayed-value><stored-value>181270</stored-value></pair>
-<pair><displayed-value>Banner, Matthew</displayed-value><stored-value>713464</stored-value></pair>
-
-<pair><displayed-value>Bansal, Arun</displayed-value><stored-value>1137366</stored-value></pair>
-<pair><displayed-value>Bansal, Arun</displayed-value><stored-value>1095769</stored-value></pair>
-<pair><displayed-value>Bar-Isaac, Heski</displayed-value><stored-value>380567</stored-value></pair>
-<pair><displayed-value>Bar-Yosef, Sasson</displayed-value><stored-value>55919</stored-value></pair>
-<pair><displayed-value>Baranes, Edmond</displayed-value><stored-value>381568</stored-value></pair>
-<pair><displayed-value>Barbarino, Alessandro</displayed-value><stored-value>761685</stored-value></pair>
-
-<pair><displayed-value>Barber, Raymond E.</displayed-value><stored-value>1143340</stored-value></pair>
-<pair><displayed-value>Barberis, Nicholas</displayed-value><stored-value>51524</stored-value></pair>
-<pair><displayed-value>Barclay, Michael J.</displayed-value><stored-value>16890</stored-value></pair>
-<pair><displayed-value>Barczi, Nathan A</displayed-value><stored-value>656913</stored-value></pair>
-<pair><displayed-value>Barone-Adesi, Giovanni</displayed-value><stored-value>12245</stored-value></pair>
-<pair><displayed-value>Baroudi, Jack</displayed-value><stored-value>1141329</stored-value></pair>
-
-<pair><displayed-value>Baroudi, Jack J.</displayed-value><stored-value>390343</stored-value></pair>
-<pair><displayed-value>Baroudi, Jack Joseph</displayed-value><stored-value>1143341</stored-value></pair>
-<pair><displayed-value>Bartov, Eli</displayed-value><stored-value>17599</stored-value></pair>
-<pair><displayed-value>Baruch, Shmuel</displayed-value><stored-value>79677</stored-value></pair>
-<pair><displayed-value>Basak, Suleyman</displayed-value><stored-value>16892</stored-value></pair>
-<pair><displayed-value>Battalio, Robert H.</displayed-value><stored-value>46218</stored-value></pair>
-
-<pair><displayed-value>Battigalli, Pierpaolo</displayed-value><stored-value>141868</stored-value></pair>
-<pair><displayed-value>Baumol, William J.</displayed-value><stored-value>46051</stored-value></pair>
-<pair><displayed-value>Bazerman, Max H.</displayed-value><stored-value>273075</stored-value></pair>
-<pair><displayed-value>Bear, Larry Alan</displayed-value><stored-value>1148480</stored-value></pair>
-<pair><displayed-value>Bear, Rita Maldonado-</displayed-value><stored-value>1151913</stored-value></pair>
-<pair><displayed-value>Beath, Cynthia Mathis</displayed-value><stored-value>1135969</stored-value></pair>
-
-<pair><displayed-value>Bebchuk, Lucian A.</displayed-value><stored-value>17037</stored-value></pair>
-<pair><displayed-value>Beck, Andrew</displayed-value><stored-value>523204</stored-value></pair>
-<pair><displayed-value>Becker, William E.</displayed-value><stored-value>76802</stored-value></pair>
-<pair><displayed-value>Behnke, Tara</displayed-value><stored-value>199490</stored-value></pair>
-<pair><displayed-value>Benabou, Roland</displayed-value><stored-value>45380</stored-value></pair>
-<pair><displayed-value>Benaroch, Michel</displayed-value><stored-value>1142292</stored-value></pair>
-
-<pair><displayed-value>Benbunan-Fich, Raquel</displayed-value><stored-value>1133790</stored-value></pair>
-<pair><displayed-value>Beneish, Messod Daniel</displayed-value><stored-value>16194</stored-value></pair>
-<pair><displayed-value>Bennedsen, Morten</displayed-value><stored-value>176126</stored-value></pair>
-<pair><displayed-value>Bennett, Paul</displayed-value><stored-value>60007</stored-value></pair>
-<pair><displayed-value>Benveniste, Lawrence M.</displayed-value><stored-value>31751</stored-value></pair>
-<pair><displayed-value>Berd, Arthur M.</displayed-value><stored-value>437295</stored-value></pair>
-
-<pair><displayed-value>Berger, Allen N.</displayed-value><stored-value>2141</stored-value></pair>
-<pair><displayed-value>Berger, Gideon</displayed-value><stored-value>1141324</stored-value></pair>
-<pair><displayed-value>Berger, Peter</displayed-value><stored-value>1153607</stored-value></pair>
-<pair><displayed-value>Berger, Philip G.</displayed-value><stored-value>560130</stored-value></pair>
-<pair><displayed-value>Bergstresser, Daniel B.</displayed-value><stored-value>222235</stored-value></pair>
-<pair><displayed-value>Berkowitz, Jeremy</displayed-value><stored-value>15008</stored-value></pair>
-
-<pair><displayed-value>Berlin, Mitchell</displayed-value><stored-value>52780</stored-value></pair>
-<pair><displayed-value>Berlowitz, Leslie</displayed-value><stored-value>1145081</stored-value></pair>
-<pair><displayed-value>Berman, Simeon M.</displayed-value><stored-value>1143357</stored-value></pair>
-<pair><displayed-value>Berndt, Donald J.</displayed-value><stored-value>1135963</stored-value></pair>
-<pair><displayed-value>Bernstein, Abraham</displayed-value><stored-value>665196</stored-value></pair>
-<pair><displayed-value>Bertola, Giuseppe</displayed-value><stored-value>1958</stored-value></pair>
-
-<pair><displayed-value>Bhagwati, Jagdish</displayed-value><stored-value>239710</stored-value></pair>
-<pair><displayed-value>Bharath, Sreedhar T.</displayed-value><stored-value>303039</stored-value></pair>
-<pair><displayed-value>Bhardwaj, Pradeep</displayed-value><stored-value>388814</stored-value></pair>
-<pair><displayed-value>Bhasker, S.</displayed-value><stored-value>1142082</stored-value></pair>
-<pair><displayed-value>Bhattacharjee, Sudip</displayed-value><stored-value>370225</stored-value></pair>
-<pair><displayed-value>Bickart, Barbara A.</displayed-value><stored-value>713470</stored-value></pair>
-
-<pair><displayed-value>Bieber, Michael</displayed-value><stored-value>1135952</stored-value></pair>
-<pair><displayed-value>Bierens, Herman J.</displayed-value><stored-value>81119</stored-value></pair>
-<pair><displayed-value>Biggs, John H.</displayed-value><stored-value>346528</stored-value></pair>
-<pair><displayed-value>Bikson, Tora K.</displayed-value><stored-value>1142064</stored-value></pair>
-<pair><displayed-value>Billings, Mary Brooke</displayed-value><stored-value>397469</stored-value></pair>
-<pair><displayed-value>Binbasioglu, Meral</displayed-value><stored-value>582169</stored-value></pair>
-
-<pair><displayed-value>Bisin, Alberto</displayed-value><stored-value>145796</stored-value></pair>
-<pair><displayed-value>Bitran, Gabriel R.</displayed-value><stored-value>17385</stored-value></pair>
-<pair><displayed-value>Bizid, Abdelhamid</displayed-value><stored-value>852207</stored-value></pair>
-<pair><displayed-value>Bjorn-Andersen, Niels</displayed-value><stored-value>1135964</stored-value></pair>
-<pair><displayed-value>Blake, Christopher R.</displayed-value><stored-value>58711</stored-value></pair>
-<pair><displayed-value>Blanchard, Olivier J.</displayed-value><stored-value>21488</stored-value></pair>
-
-<pair><displayed-value>Bloch, Michael</displayed-value><stored-value>497123</stored-value></pair>
-<pair><displayed-value>Block, Lauren</displayed-value><stored-value>334010</stored-value></pair>
-<pair><displayed-value>Bloomfield, Robert J.</displayed-value><stored-value>48324</stored-value></pair>
-<pair><displayed-value>Bodnar, Gordon M.</displayed-value><stored-value>27276</stored-value></pair>
-<pair><displayed-value>Bodoff, David</displayed-value><stored-value>1133982</stored-value></pair>
-<pair><displayed-value>Boehmer, Ekkehart</displayed-value><stored-value>38106</stored-value></pair>
-
-<pair><displayed-value>Bollerslev, Tim</displayed-value><stored-value>17698</stored-value></pair>
-<pair><displayed-value>Bonime, Seth D.</displayed-value><stored-value>160259</stored-value></pair>
-<pair><displayed-value>Bonin, John P.</displayed-value><stored-value>38364</stored-value></pair>
-<pair><displayed-value>Bonomo, Marco</displayed-value><stored-value>49860</stored-value></pair>
-<pair><displayed-value>Boskin, Michael J.</displayed-value><stored-value>229678</stored-value></pair>
-<pair><displayed-value>Boudoukh, Jacob (Kobi)</displayed-value><stored-value>17601</stored-value></pair>
-
-<pair><displayed-value>Boudry, Walter</displayed-value><stored-value>352418</stored-value></pair>
-<pair><displayed-value>Boyko, Victor</displayed-value><stored-value>1135962</stored-value></pair>
-<pair><displayed-value>Bradford, David F.</displayed-value><stored-value>46623</stored-value></pair>
-<pair><displayed-value>Brady, Brooks</displayed-value><stored-value>328965</stored-value></pair>
-<pair><displayed-value>Braguinsky, Serguey</displayed-value><stored-value>328812</stored-value></pair>
-<pair><displayed-value>Brandenburger, Adam M.</displayed-value><stored-value>57808</stored-value></pair>
-
-<pair><displayed-value>Brands, Simone</displayed-value><stored-value>486166</stored-value></pair>
-<pair><displayed-value>Brandt, Michael W.</displayed-value><stored-value>161226</stored-value></pair>
-<pair><displayed-value>Brechner, Matias</displayed-value><stored-value>447583</stored-value></pair>
-<pair><displayed-value>Brenner, Menachem</displayed-value><stored-value>20827</stored-value></pair>
-<pair><displayed-value>Brief, Arthur P.</displayed-value><stored-value>1142959</stored-value></pair>
-<pair><displayed-value>Brief, Richard P.</displayed-value><stored-value>20875</stored-value></pair>
-
-<pair><displayed-value>Brito, Jos√à Almeida</displayed-value><stored-value>1147627</stored-value></pair>
-<pair><displayed-value>Brodsky, Julia</displayed-value><stored-value>1144328</stored-value></pair>
-<pair><displayed-value>Bront, Juan Jose Miranda</displayed-value><stored-value>1156906</stored-value></pair>
-<pair><displayed-value>Brown, Stephen J.</displayed-value><stored-value>2321</stored-value></pair>
-<pair><displayed-value>Brunnermeier, Markus Konrad</displayed-value><stored-value>70328</stored-value></pair>
-<pair><displayed-value>Brusco, Sandro</displayed-value><stored-value>365798</stored-value></pair>
-
-<pair><displayed-value>Bryan, Stephen H.</displayed-value><stored-value>180110</stored-value></pair>
-<pair><displayed-value>Brynjolfsson, Erik</displayed-value><stored-value>25688</stored-value></pair>
-<pair><displayed-value>Buchanan, Bruce</displayed-value><stored-value>79838</stored-value></pair>
-<pair><displayed-value>Buelens, Frans</displayed-value><stored-value>837464</stored-value></pair>
-<pair><displayed-value>Bui, Tung</displayed-value><stored-value>1143313</stored-value></pair>
-<pair><displayed-value>Burns, Patrick J.</displayed-value><stored-value>59330</stored-value></pair>
-
-<pair><displayed-value>Burrus, Jeremy</displayed-value><stored-value>713370</stored-value></pair>
-<pair><displayed-value>Busse, Jeffrey A.</displayed-value><stored-value>110029</stored-value></pair>
-<pair><displayed-value>Butensky, Noah E.</displayed-value><stored-value>344407</stored-value></pair>
-<pair><displayed-value>B¬∏lb¬∏l, Cenk</displayed-value><stored-value>712107</stored-value></pair>
-<pair><displayed-value>CALLEN, JEFFREY L.</displayed-value><stored-value>574539</stored-value></pair>
-<pair><displayed-value>Cabral, Luis M.B.</displayed-value><stored-value>75382</stored-value></pair>
-
-<pair><displayed-value>Caby, Laurence</displayed-value><stored-value>1135978</stored-value></pair>
-<pair><displayed-value>Cakici, Nusret</displayed-value><stored-value>108542</stored-value></pair>
-<pair><displayed-value>Caldentey, Ren'e</displayed-value><stored-value>1147158</stored-value></pair>
-<pair><displayed-value>Caldentey, Rene</displayed-value><stored-value>337731</stored-value></pair>
-<pair><displayed-value>Caldentey, Ren√à A.</displayed-value><stored-value>1147157</stored-value></pair>
-<pair><displayed-value>Callen, Jeffrey L.</displayed-value><stored-value>17573</stored-value></pair>
-
-<pair><displayed-value>Calloway, Linda-Jo</displayed-value><stored-value>1142955</stored-value></pair>
-<pair><displayed-value>Calvet, Laurent E.</displayed-value><stored-value>75695</stored-value></pair>
-<pair><displayed-value>Camp, L. Jean</displayed-value><stored-value>262477</stored-value></pair>
-<pair><displayed-value>Campa, Jos√à Manuel</displayed-value><stored-value>17603</stored-value></pair>
-<pair><displayed-value>Campanale, Claudio</displayed-value><stored-value>383365</stored-value></pair>
-<pair><displayed-value>Campanale, Claudio</displayed-value><stored-value>812500</stored-value></pair>
-
-<pair><displayed-value>Campbell, John Y.</displayed-value><stored-value>17060</stored-value></pair>
-<pair><displayed-value>Campello, Murillo</displayed-value><stored-value>107816</stored-value></pair>
-<pair><displayed-value>Canals, Claudia</displayed-value><stored-value>385772</stored-value></pair>
-<pair><displayed-value>Canina, Linda</displayed-value><stored-value>353639</stored-value></pair>
-<pair><displayed-value>Cantillon, Estelle</displayed-value><stored-value>265156</stored-value></pair>
-<pair><displayed-value>Capkun, Vedran</displayed-value><stored-value>429781</stored-value></pair>
-
-<pair><displayed-value>Cappiello, Lorenzo</displayed-value><stored-value>234084</stored-value></pair>
-<pair><displayed-value>Caprio, Gerard Jr.</displayed-value><stored-value>1152395</stored-value></pair>
-<pair><displayed-value>Carcello, Joseph V.</displayed-value><stored-value>47320</stored-value></pair>
-<pair><displayed-value>Carhart, Mark M.</displayed-value><stored-value>36900</stored-value></pair>
-<pair><displayed-value>Carmel, Judith Rachelle</displayed-value><stored-value>384509</stored-value></pair>
-<pair><displayed-value>Carpenter, Jennifer N.</displayed-value><stored-value>17605</stored-value></pair>
-
-<pair><displayed-value>Carr, Peter P.</displayed-value><stored-value>707</stored-value></pair>
-<pair><displayed-value>Carter, Karen</displayed-value><stored-value>387943</stored-value></pair>
-<pair><displayed-value>Caruana, Guillermo</displayed-value><stored-value>333919</stored-value></pair>
-<pair><displayed-value>Casadesus-Masanell, Ramon</displayed-value><stored-value>231841</stored-value></pair>
-<pair><displayed-value>Castro, Rui</displayed-value><stored-value>947502</stored-value></pair>
-<pair><displayed-value>Caucutt, Elizabeth M.</displayed-value><stored-value>274874</stored-value></pair>
-
-<pair><displayed-value>Cavusoglu, Hasan</displayed-value><stored-value>803558</stored-value></pair>
-<pair><displayed-value>Cavusoglu, Huseyin</displayed-value><stored-value>422930</stored-value></pair>
-<pair><displayed-value>Cays, Stephen E.</displayed-value><stored-value>1133337</stored-value></pair>
-<pair><displayed-value>Cebenoyan, A. Sinan</displayed-value><stored-value>1148426</stored-value></pair>
-<pair><displayed-value>Cebenoyan, Fatma</displayed-value><stored-value>404843</stored-value></pair>
-<pair><displayed-value>Chacko, George</displayed-value><stored-value>195217</stored-value></pair>
-
-<pair><displayed-value>Chakravarti, Amitav</displayed-value><stored-value>473669</stored-value></pair>
-<pair><displayed-value>Chambers, John R.</displayed-value><stored-value>713434</stored-value></pair>
-<pair><displayed-value>Chan, Justin Sai-Pang</displayed-value><stored-value>400437</stored-value></pair>
-<pair><displayed-value>Chanda, Ananda</displayed-value><stored-value>456963</stored-value></pair>
-<pair><displayed-value>Chandon, Pierre</displayed-value><stored-value>109253</stored-value></pair>
-<pair><displayed-value>Chandra, Ambarish</displayed-value><stored-value>810291</stored-value></pair>
-
-<pair><displayed-value>Chang, Elaine</displayed-value><stored-value>569920</stored-value></pair>
-<pair><displayed-value>Chang, P.H. Kevin</displayed-value><stored-value>53300</stored-value></pair>
-<pair><displayed-value>Chang, Roberto</displayed-value><stored-value>48780</stored-value></pair>
-<pair><displayed-value>Chapman, David A.</displayed-value><stored-value>17462</stored-value></pair>
-<pair><displayed-value>Chay, J. B.</displayed-value><stored-value>1151309</stored-value></pair>
-<pair><displayed-value>Checroun, Alain</displayed-value><stored-value>1143317</stored-value></pair>
-
-<pair><displayed-value>Cheema, Amar</displayed-value><stored-value>385546</stored-value></pair>
-<pair><displayed-value>Chemla, Gilles</displayed-value><stored-value>22734</stored-value></pair>
-<pair><displayed-value>Chemmanur, Thomas J.</displayed-value><stored-value>16097</stored-value></pair>
-<pair><displayed-value>Chen, Hsinchun</displayed-value><stored-value>636787</stored-value></pair>
-<pair><displayed-value>Chen, Pei-Yu</displayed-value><stored-value>370962</stored-value></pair>
-<pair><displayed-value>Chen, Willa W</displayed-value><stored-value>481802</stored-value></pair>
-
-<pair><displayed-value>Chen, Xiaohong</displayed-value><stored-value>30333</stored-value></pair>
-<pair><displayed-value>Chen, Xin</displayed-value><stored-value>1147510</stored-value></pair>
-<pair><displayed-value>Chen, Yeh-Ning</displayed-value><stored-value>136397</stored-value></pair>
-<pair><displayed-value>Chen, Yehning</displayed-value><stored-value>449212</stored-value></pair>
-<pair><displayed-value>Chen, Yongmin</displayed-value><stored-value>49472</stored-value></pair>
-<pair><displayed-value>Chen, Yuxin</displayed-value><stored-value>67048</stored-value></pair>
-
-<pair><displayed-value>Chiang, Eric P.</displayed-value><stored-value>640314</stored-value></pair>
-<pair><displayed-value>Chib, Siddhartha</displayed-value><stored-value>44961</stored-value></pair>
-<pair><displayed-value>Chidambaran, N. K.</displayed-value><stored-value>15983</stored-value></pair>
-<pair><displayed-value>Ching, Andrew</displayed-value><stored-value>609077</stored-value></pair>
-<pair><displayed-value>Chinn, Menzie David</displayed-value><stored-value>15131</stored-value></pair>
-<pair><displayed-value>Chiou, Ingyu</displayed-value><stored-value>113540</stored-value></pair>
-
-<pair><displayed-value>Cho, Jang-Ok</displayed-value><stored-value>84428</stored-value></pair>
-<pair><displayed-value>Cho, Junghoo</displayed-value><stored-value>1131961</stored-value></pair>
-<pair><displayed-value>Choi, Frederick D.S.</displayed-value><stored-value>20881</stored-value></pair>
-<pair><displayed-value>Choi, Jay Pil</displayed-value><stored-value>16079</stored-value></pair>
-<pair><displayed-value>Chokshi, Narendra</displayed-value><stored-value>1133324</stored-value></pair>
-<pair><displayed-value>Chou, Dashin</displayed-value><stored-value>1133786</stored-value></pair>
-
-<pair><displayed-value>Choudhary, Vidyanand</displayed-value><stored-value>331630</stored-value></pair>
-<pair><displayed-value>Christoffersen, Peter</displayed-value><stored-value>39700</stored-value></pair>
-<pair><displayed-value>Christou, Nicolas</displayed-value><stored-value>1144329</stored-value></pair>
-<pair><displayed-value>Chugh, Dolly</displayed-value><stored-value>327840</stored-value></pair>
-<pair><displayed-value>Chung, Wilbur C.</displayed-value><stored-value>269571</stored-value></pair>
-<pair><displayed-value>Ciarreta, Aitor</displayed-value><stored-value>884350</stored-value></pair>
-
-<pair><displayed-value>Ciborra, Claudio</displayed-value><stored-value>677721</stored-value></pair>
-<pair><displayed-value>Cicchetti, Charles J.</displayed-value><stored-value>908477</stored-value></pair>
-<pair><displayed-value>Ciftci, Mustafa</displayed-value><stored-value>405203</stored-value></pair>
-<pair><displayed-value>Cipollini, Fabrizio</displayed-value><stored-value>708630</stored-value></pair>
-<pair><displayed-value>Clarke, Colin P</displayed-value><stored-value>394079</stored-value></pair>
-<pair><displayed-value>Clayton, Matthew J.</displayed-value><stored-value>20835</stored-value></pair>
-
-<pair><displayed-value>Clayton, Matthew</displayed-value><stored-value>1148834</stored-value></pair>
-<pair><displayed-value>Clearwater, Scott</displayed-value><stored-value>1133774</stored-value></pair>
-<pair><displayed-value>Clementi, Gian Luca</displayed-value><stored-value>328593</stored-value></pair>
-<pair><displayed-value>Clemons, Eric K.</displayed-value><stored-value>17523</stored-value></pair>
-<pair><displayed-value>Clifford, James</displayed-value><stored-value>1133955</stored-value></pair>
-<pair><displayed-value>Clifford, Jim</displayed-value><stored-value>1143321</stored-value></pair>
-
-<pair><displayed-value>Cohen, Daniel A.</displayed-value><stored-value>118206</stored-value></pair>
-<pair><displayed-value>Colacito, Riccardo</displayed-value><stored-value>698614</stored-value></pair>
-<pair><displayed-value>Cole, Rebel A.</displayed-value><stored-value>15769</stored-value></pair>
-<pair><displayed-value>Collard-Wexler, Allan</displayed-value><stored-value>810290</stored-value></pair>
-<pair><displayed-value>College of Business Administration, UIC</displayed-value><stored-value>1137857</stored-value></pair>
-<pair><displayed-value>Comer, George</displayed-value><stored-value>363573</stored-value></pair>
-
-<pair><displayed-value>Comin, Diego</displayed-value><stored-value>105076</stored-value></pair>
-<pair><displayed-value>Commer, George</displayed-value><stored-value>328663</stored-value></pair>
-<pair><displayed-value>Com√ån, Diego</displayed-value><stored-value>1154638</stored-value></pair>
-<pair><displayed-value>Cooke, Alan D.J.</displayed-value><stored-value>62935</stored-value></pair>
-<pair><displayed-value>Cooke, Diane</displayed-value><stored-value>1149823</stored-value></pair>
-<pair><displayed-value>Cooley, Thomas F.</displayed-value><stored-value>17456</stored-value></pair>
-
-<pair><displayed-value>Cooperman, Elizabeth S.</displayed-value><stored-value>124770</stored-value></pair>
-<pair><displayed-value>Coplan, Judson L</displayed-value><stored-value>572447</stored-value></pair>
-<pair><displayed-value>Corfman, Kim</displayed-value><stored-value>390835</stored-value></pair>
-<pair><displayed-value>Cornelli, Francesca</displayed-value><stored-value>1452</stored-value></pair>
-<pair><displayed-value>Cornett, Marcia Millon</displayed-value><stored-value>1149013</stored-value></pair>
-<pair><displayed-value>Corsetti, Giancarlo</displayed-value><stored-value>1363</stored-value></pair>
-
-<pair><displayed-value>Corts, Kenneth S.</displayed-value><stored-value>60589</stored-value></pair>
-<pair><displayed-value>Cox, James C.</displayed-value><stored-value>32930</stored-value></pair>
-<pair><displayed-value>Craig, Charles Samuel</displayed-value><stored-value>52797</stored-value></pair>
-<pair><displayed-value>Cramton, Peter C.</displayed-value><stored-value>146596</stored-value></pair>
-<pair><displayed-value>Crandall, Robert</displayed-value><stored-value>256044</stored-value></pair>
-<pair><displayed-value>Cranor, Lorrie Faith</displayed-value><stored-value>333622</stored-value></pair>
-
-<pair><displayed-value>Cremers, K.J. Martijn</displayed-value><stored-value>254417</stored-value></pair>
-<pair><displayed-value>Creus Mir, Albert</displayed-value><stored-value>701980</stored-value></pair>
-<pair><displayed-value>Creutz, Douglas</displayed-value><stored-value>1133332</stored-value></pair>
-<pair><displayed-value>Croce, Mariano Massimiliano</displayed-value><stored-value>571252</stored-value></pair>
-<pair><displayed-value>Croker, Albert</displayed-value><stored-value>447151</stored-value></pair>
-<pair><displayed-value>Cropper, Maureen L.</displayed-value><stored-value>224652</stored-value></pair>
-
-<pair><displayed-value>Crowley, Gwyneth</displayed-value><stored-value>63988</stored-value></pair>
-<pair><displayed-value>Cunat, Vicente</displayed-value><stored-value>653515</stored-value></pair>
-<pair><displayed-value>Cusick, Philip</displayed-value><stored-value>344409</stored-value></pair>
-<pair><displayed-value>Cuyvers, Ludo</displayed-value><stored-value>1148135</stored-value></pair>
-<pair><displayed-value>Dafria, Ashish</displayed-value><stored-value>1133333</stored-value></pair>
-<pair><displayed-value>Dahiya, Sandeep</displayed-value><stored-value>231384</stored-value></pair>
-
-<pair><displayed-value>Dahiyaa, Sandeep</displayed-value><stored-value>1145077</stored-value></pair>
-<pair><displayed-value>Dahleh, Munther</displayed-value><stored-value>1033602</stored-value></pair>
-<pair><displayed-value>Dai, Qiang</displayed-value><stored-value>139423</stored-value></pair>
-<pair><displayed-value>Dai, Qiang</displayed-value><stored-value>1098860</stored-value></pair>
-<pair><displayed-value>Daines, Robert</displayed-value><stored-value>181293</stored-value></pair>
-<pair><displayed-value>Daly, George</displayed-value><stored-value>82782</stored-value></pair>
-
-<pair><displayed-value>Damodaran, Aswath</displayed-value><stored-value>20838</stored-value></pair>
-<pair><displayed-value>Darrough, Masako N.</displayed-value><stored-value>16153</stored-value></pair>
-<pair><displayed-value>Das, Sanjiv Ranjan</displayed-value><stored-value>17108</stored-value></pair>
-<pair><displayed-value>David, Backus</displayed-value><stored-value>1151295</stored-value></pair>
-<pair><displayed-value>David, Yermack</displayed-value><stored-value>1152401</stored-value></pair>
-<pair><displayed-value>Davidenko, Nicolas</displayed-value><stored-value>845619</stored-value></pair>
-
-<pair><displayed-value>Davis Hodder, Leslie D.</displayed-value><stored-value>214480</stored-value></pair>
-<pair><displayed-value>De Loecker, Jan</displayed-value><stored-value>362360</stored-value></pair>
-<pair><displayed-value>DeLong, Gayle L.</displayed-value><stored-value>261582</stored-value></pair>
-<pair><displayed-value>DeLongb, Gayle L.</displayed-value><stored-value>1148140</stored-value></pair>
-<pair><displayed-value>DeMarzo, Peter M.</displayed-value><stored-value>17717</stored-value></pair>
-<pair><displayed-value>DeMuth, Christopher</displayed-value><stored-value>233599</stored-value></pair>
-
-<pair><displayed-value>DeYoung, Robert</displayed-value><stored-value>2280</stored-value></pair>
-<pair><displayed-value>Dellarocas, Chrysanthos N.</displayed-value><stored-value>25705</stored-value></pair>
-<pair><displayed-value>Demers, Elizabeth A.</displayed-value><stored-value>47023</stored-value></pair>
-<pair><displayed-value>Demsetz, Harold</displayed-value><stored-value>93805</stored-value></pair>
-<pair><displayed-value>Denrell, Jerker</displayed-value><stored-value>557026</stored-value></pair>
-<pair><displayed-value>Deo, Rohit</displayed-value><stored-value>683519</stored-value></pair>
-
-<pair><displayed-value>Dermody, Jaime Cuevas</displayed-value><stored-value>1153783</stored-value></pair>
-<pair><displayed-value>Deuskar, Prachi</displayed-value><stored-value>352440</stored-value></pair>
-<pair><displayed-value>Dew, Jeven</displayed-value><stored-value>673016</stored-value></pair>
-<pair><displayed-value>Dey, Aiyesha</displayed-value><stored-value>118212</stored-value></pair>
-<pair><displayed-value>Dezso, Cristian L.</displayed-value><stored-value>467267</stored-value></pair>
-<pair><displayed-value>Dhar, Ravi</displayed-value><stored-value>194452</stored-value></pair>
-
-<pair><displayed-value>Dhar, Vasant</displayed-value><stored-value>402993</stored-value></pair>
-<pair><displayed-value>Dholakia, Utpal M.</displayed-value><stored-value>107512</stored-value></pair>
-<pair><displayed-value>Diamond, Lester</displayed-value><stored-value>1142949</stored-value></pair>
-<pair><displayed-value>Diaz, Alicia</displayed-value><stored-value>1135958</stored-value></pair>
-<pair><displayed-value>Dick, Astrid Andrea</displayed-value><stored-value>47137</stored-value></pair>
-<pair><displayed-value>Diebold, Francis X.</displayed-value><stored-value>15004</stored-value></pair>
-
-<pair><displayed-value>Ding, Yufeng</displayed-value><stored-value>1147168</stored-value></pair>
-<pair><displayed-value>Ding, Zhuanxin</displayed-value><stored-value>1148829</stored-value></pair>
-<pair><displayed-value>Doan, Anhai</displayed-value><stored-value>1131967</stored-value></pair>
-<pair><displayed-value>Dontoh, Alex</displayed-value><stored-value>20883</stored-value></pair>
-<pair><displayed-value>Douglas, Jason</displayed-value><stored-value>656933</stored-value></pair>
-<pair><displayed-value>Douglas, Susan</displayed-value><stored-value>333320</stored-value></pair>
-
-<pair><displayed-value>Doukas, John A.</displayed-value><stored-value>54251</stored-value></pair>
-<pair><displayed-value>Dreze, Xavier</displayed-value><stored-value>703349</stored-value></pair>
-<pair><displayed-value>Driscoll, John C.</displayed-value><stored-value>173992</stored-value></pair>
-<pair><displayed-value>Dubin, Jeffrey A.</displayed-value><stored-value>181569</stored-value></pair>
-<pair><displayed-value>Duffie, Darrell</displayed-value><stored-value>829363</stored-value></pair>
-<pair><displayed-value>Duliba, Katherine A.</displayed-value><stored-value>1135950</stored-value></pair>
-
-<pair><displayed-value>Dunning, David</displayed-value><stored-value>300351</stored-value></pair>
-<pair><displayed-value>Durnev, Artyom</displayed-value><stored-value>257034</stored-value></pair>
-<pair><displayed-value>Durtschi, Cindy</displayed-value><stored-value>253409</stored-value></pair>
-<pair><displayed-value>Dutta, Prajit K.</displayed-value><stored-value>53700</stored-value></pair>
-<pair><displayed-value>Dwyer, Mark</displayed-value><stored-value>90068</stored-value></pair>
-<pair><displayed-value>Dybvig, Philip H.</displayed-value><stored-value>56096</stored-value></pair>
-
-<pair><displayed-value>Dyreson, Curtis</displayed-value><stored-value>1135948</stored-value></pair>
-<pair><displayed-value>E. Sokalska, Magdalena</displayed-value><stored-value>1147621</stored-value></pair>
-<pair><displayed-value>Eads, George</displayed-value><stored-value>711493</stored-value></pair>
-<pair><displayed-value>Easley, David</displayed-value><stored-value>58370</stored-value></pair>
-<pair><displayed-value>Economics Department, UCSC</displayed-value><stored-value>356535</stored-value></pair>
-<pair><displayed-value>Economides, Nicholas</displayed-value><stored-value>1720</stored-value></pair>
-
-<pair><displayed-value>Eden, Yoram</displayed-value><stored-value>1142948</stored-value></pair>
-<pair><displayed-value>Editor, JOIM</displayed-value><stored-value>363704</stored-value></pair>
-<pair><displayed-value>Edmans, Alex</displayed-value><stored-value>393296</stored-value></pair>
-<pair><displayed-value>Edmond, Chris</displayed-value><stored-value>266360</stored-value></pair>
-<pair><displayed-value>Ehrlinger, Joyce</displayed-value><stored-value>713456</stored-value></pair>
-<pair><displayed-value>Eisenach, Jeffrey A.</displayed-value><stored-value>827975</stored-value></pair>
-
-<pair><displayed-value>Eisner, Alan B</displayed-value><stored-value>620510</stored-value></pair>
-<pair><displayed-value>El Barmi, Hammou</displayed-value><stored-value>1144327</stored-value></pair>
-<pair><displayed-value>Eldor, Rafi</displayed-value><stored-value>1153785</stored-value></pair>
-<pair><displayed-value>Elera, Nancy</displayed-value><stored-value>114544</stored-value></pair>
-<pair><displayed-value>Elmagarmid, Ahmed</displayed-value><stored-value>1131958</stored-value></pair>
-<pair><displayed-value>Elton, Edwin J.</displayed-value><stored-value>17581</stored-value></pair>
-
-<pair><displayed-value>Elzinga, Kenneth G.</displayed-value><stored-value>329167</stored-value></pair>
-<pair><displayed-value>Emre, Onsel</displayed-value><stored-value>368724</stored-value></pair>
-<pair><displayed-value>Engle, Robert F.</displayed-value><stored-value>16242</stored-value></pair>
-<pair><displayed-value>Eom, Young Ho</displayed-value><stored-value>104388</stored-value></pair>
-<pair><displayed-value>Erdem, Tulin</displayed-value><stored-value>760817</stored-value></pair>
-<pair><displayed-value>Evans, Matt</displayed-value><stored-value>713386</stored-value></pair>
-
-<pair><displayed-value>Fairlie, Robert W.</displayed-value><stored-value>457</stored-value></pair>
-<pair><displayed-value>Faktorovich, Mark</displayed-value><stored-value>1133322</stored-value></pair>
-<pair><displayed-value>Fan, Zhenhong</displayed-value><stored-value>1145634</stored-value></pair>
-<pair><displayed-value>Fang, Christina</displayed-value><stored-value>361860</stored-value></pair>
-<pair><displayed-value>Farhi, Emmanuel</displayed-value><stored-value>296514</stored-value></pair>
-<pair><displayed-value>Farnsworth, Heber</displayed-value><stored-value>20154</stored-value></pair>
-
-<pair><displayed-value>Fat¬∑s, Enrique</displayed-value><stored-value>260988</stored-value></pair>
-<pair><displayed-value>Faulhaber, Gerald R.</displayed-value><stored-value>17516</stored-value></pair>
-<pair><displayed-value>Faurel, Lucile</displayed-value><stored-value>440412</stored-value></pair>
-<pair><displayed-value>Favilukis, Jack Y</displayed-value><stored-value>696288</stored-value></pair>
-<pair><displayed-value>Fehrs, Donald H.</displayed-value><stored-value>1153784</stored-value></pair>
-<pair><displayed-value>Feld, Scott L</displayed-value><stored-value>1145079</stored-value></pair>
-
-<pair><displayed-value>Feldman, Ronen</displayed-value><stored-value>343970</stored-value></pair>
-<pair><displayed-value>Feldman, Ronen</displayed-value><stored-value>605313</stored-value></pair>
-<pair><displayed-value>Ferguson, Niall</displayed-value><stored-value>433226</stored-value></pair>
-<pair><displayed-value>Fernandez, Raquel</displayed-value><stored-value>42714</stored-value></pair>
-<pair><displayed-value>Fernando, Chitru S.</displayed-value><stored-value>21888</stored-value></pair>
-<pair><displayed-value>Ferreira, Daniel</displayed-value><stored-value>327077</stored-value></pair>
-
-<pair><displayed-value>Ferstenberg, Robert</displayed-value><stored-value>610529</stored-value></pair>
-<pair><displayed-value>Fessel, Florian</displayed-value><stored-value>713436</stored-value></pair>
-<pair><displayed-value>Figlewski, Stephen</displayed-value><stored-value>17609</stored-value></pair>
-<pair><displayed-value>Figueroa, Nicol¬∑s</displayed-value><stored-value>1133565</stored-value></pair>
-<pair><displayed-value>Finch, Nigel</displayed-value><stored-value>438461</stored-value></pair>
-<pair><displayed-value>Finin, Tim</displayed-value><stored-value>1142950</stored-value></pair>
-
-<pair><displayed-value>Fish, Michael</displayed-value><stored-value>661974</stored-value></pair>
-<pair><displayed-value>Fisher, Adlai J.</displayed-value><stored-value>75693</stored-value></pair>
-<pair><displayed-value>Fisher, Eric</displayed-value><stored-value>1142312</stored-value></pair>
-<pair><displayed-value>Fisher, Franklin M.</displayed-value><stored-value>21504</stored-value></pair>
-<pair><displayed-value>Fisher, Marshall</displayed-value><stored-value>872814</stored-value></pair>
-<pair><displayed-value>Fitch, Eliezer M.</displayed-value><stored-value>1146527</stored-value></pair>
-
-<pair><displayed-value>Flamm, Kenneth</displayed-value><stored-value>337784</stored-value></pair>
-<pair><displayed-value>Floyd, Barry</displayed-value><stored-value>1142079</stored-value></pair>
-<pair><displayed-value>Fluck, Zsuzsanna</displayed-value><stored-value>17660</stored-value></pair>
-<pair><displayed-value>Flyer, Fredrick</displayed-value><stored-value>20756</stored-value></pair>
-<pair><displayed-value>Fogli, Alessandra</displayed-value><stored-value>333202</stored-value></pair>
-<pair><displayed-value>Foley, C. Fritz</displayed-value><stored-value>285633</stored-value></pair>
-
-<pair><displayed-value>Fong, Christina M.</displayed-value><stored-value>335141</stored-value></pair>
-<pair><displayed-value>Foresi, Foresi</displayed-value><stored-value>1152955</stored-value></pair>
-<pair><displayed-value>Foresi, Silverio</displayed-value><stored-value>1350</stored-value></pair>
-<pair><displayed-value>Forman, Chris</displayed-value><stored-value>97179</stored-value></pair>
-<pair><displayed-value>Foster, Joseph A.</displayed-value><stored-value>634167</stored-value></pair>
-<pair><displayed-value>Fox, Jeremy T.</displayed-value><stored-value>416205</stored-value></pair>
-
-<pair><displayed-value>Fraiberger, Samuel P.</displayed-value><stored-value>1210063</stored-value></pair>
-<pair><displayed-value>Frame, W. Scott</displayed-value><stored-value>275524</stored-value></pair>
-<pair><displayed-value>Frame, W.Scott</displayed-value><stored-value>1146520</stored-value></pair>
-<pair><displayed-value>Francis, Bill B.</displayed-value><stored-value>53722</stored-value></pair>
-<pair><displayed-value>Franke, G unter</displayed-value><stored-value>1148486</stored-value></pair>
-<pair><displayed-value>Franke, G.</displayed-value><stored-value>1148473</stored-value></pair>
-
-<pair><displayed-value>Franke, Guntar</displayed-value><stored-value>1150540</stored-value></pair>
-<pair><displayed-value>Franke, Gunter</displayed-value><stored-value>1151899</stored-value></pair>
-<pair><displayed-value>Franke, G¬∏nter</displayed-value><stored-value>1151916</stored-value></pair>
-<pair><displayed-value>Frankel, Richard M.</displayed-value><stored-value>16714</stored-value></pair>
-<pair><displayed-value>Fraser, Thomas L.</displayed-value><stored-value>805763</stored-value></pair>
-<pair><displayed-value>Freeman, Seth</displayed-value><stored-value>369890</stored-value></pair>
-
-<pair><displayed-value>Fried, Dov</displayed-value><stored-value>880474</stored-value></pair>
-<pair><displayed-value>Fried, Haim Dov</displayed-value><stored-value>141200</stored-value></pair>
-<pair><displayed-value>Friedman, Milton</displayed-value><stored-value>711499</stored-value></pair>
-<pair><displayed-value>Friewald, Nils</displayed-value><stored-value>1291613</stored-value></pair>
-<pair><displayed-value>Frijnsy, Bart</displayed-value><stored-value>1151301</stored-value></pair>
-<pair><displayed-value>Frydman, Halina</displayed-value><stored-value>278768</stored-value></pair>
-
-<pair><displayed-value>Frydman, Roman</displayed-value><stored-value>17611</stored-value></pair>
-<pair><displayed-value>Gabaix, Xavier</displayed-value><stored-value>297281</stored-value></pair>
-<pair><displayed-value>Gabudean, Radu</displayed-value><stored-value>510080</stored-value></pair>
-<pair><displayed-value>Gal-Or, Esther</displayed-value><stored-value>103522</stored-value></pair>
-<pair><displayed-value>Galai, Dan</displayed-value><stored-value>55762</stored-value></pair>
-<pair><displayed-value>Galak, Jeff</displayed-value><stored-value>689111</stored-value></pair>
-
-<pair><displayed-value>Gale, Douglas M.</displayed-value><stored-value>46424</stored-value></pair>
-<pair><displayed-value>Galinsky, Adam D.</displayed-value><stored-value>327420</stored-value></pair>
-<pair><displayed-value>Gallagher, David R.</displayed-value><stored-value>114371</stored-value></pair>
-<pair><displayed-value>Gallier, Jean H.</displayed-value><stored-value>1142077</stored-value></pair>
-<pair><displayed-value>Gallivan, Michael J.</displayed-value><stored-value>1141327</stored-value></pair>
-<pair><displayed-value>Gallo, Giampiero M.</displayed-value><stored-value>140132</stored-value></pair>
-
-<pair><displayed-value>Gande, Amar</displayed-value><stored-value>52300</stored-value></pair>
-<pair><displayed-value>Gander, Amar</displayed-value><stored-value>1151904</stored-value></pair>
-<pair><displayed-value>Gantman, Nataly</displayed-value><stored-value>415887</stored-value></pair>
-<pair><displayed-value>Ganuza, Juanjo</displayed-value><stored-value>1133341</stored-value></pair>
-<pair><displayed-value>Gao, Bin</displayed-value><stored-value>740</stored-value></pair>
-<pair><displayed-value>Garbade, Kenneth</displayed-value><stored-value>128679</stored-value></pair>
-
-<pair><displayed-value>Garcia Gallego, Maria Aurora</displayed-value><stored-value>260610</stored-value></pair>
-<pair><displayed-value>Garcia-Ayuso, Manuel</displayed-value><stored-value>352881</stored-value></pair>
-<pair><displayed-value>Garleanu, Nicolae Bogdan</displayed-value><stored-value>267236</stored-value></pair>
-<pair><displayed-value>Garud, Raghu</displayed-value><stored-value>101761</stored-value></pair>
-<pair><displayed-value>Gau, Yin-Feng</displayed-value><stored-value>47240</stored-value></pair>
-<pair><displayed-value>Gaur, Vishal</displayed-value><stored-value>1111834</stored-value></pair>
-
-<pair><displayed-value>Gautier, Axel</displayed-value><stored-value>240126</stored-value></pair>
-<pair><displayed-value>Gavazza, Alessandro</displayed-value><stored-value>492846</stored-value></pair>
-<pair><displayed-value>Gavious, Arieh</displayed-value><stored-value>162408</stored-value></pair>
-<pair><displayed-value>Gavish, Bezalel</displayed-value><stored-value>793824</stored-value></pair>
-<pair><displayed-value>Gaynor, Martin S.</displayed-value><stored-value>66276</stored-value></pair>
-<pair><displayed-value>Gelb, David S.</displayed-value><stored-value>199549</stored-value></pair>
-
-<pair><displayed-value>Georgantzis, Nikolaos</displayed-value><stored-value>260609</stored-value></pair>
-<pair><displayed-value>Gertler, Mark</displayed-value><stored-value>62909</stored-value></pair>
-<pair><displayed-value>Gervais, Simon</displayed-value><stored-value>36778</stored-value></pair>
-<pair><displayed-value>Ghose, Anindya</displayed-value><stored-value>331629</stored-value></pair>
-<pair><displayed-value>Ghosh, Avijit</displayed-value><stored-value>92416</stored-value></pair>
-<pair><displayed-value>Ghysels, Eric</displayed-value><stored-value>98666</stored-value></pair>
-
-<pair><displayed-value>Gilbert, Richard J.</displayed-value><stored-value>20576</stored-value></pair>
-<pair><displayed-value>Gilchrist, Simon</displayed-value><stored-value>113569</stored-value></pair>
-<pair><displayed-value>Gille, Michel</displayed-value><stored-value>1148482</stored-value></pair>
-<pair><displayed-value>Giloni, A.</displayed-value><stored-value>1144325</stored-value></pair>
-<pair><displayed-value>Giloni, Avi</displayed-value><stored-value>1147169</stored-value></pair>
-<pair><displayed-value>Ginsberg, Ari</displayed-value><stored-value>101837</stored-value></pair>
-
-<pair><displayed-value>Ginsburg, Mark</displayed-value><stored-value>415924</stored-value></pair>
-<pair><displayed-value>Ginzberg, Michael</displayed-value><stored-value>358171</stored-value></pair>
-<pair><displayed-value>Ginzberg, Michael J.</displayed-value><stored-value>390344</stored-value></pair>
-<pair><displayed-value>Giroud, Xavier</displayed-value><stored-value>850463</stored-value></pair>
-<pair><displayed-value>Gittelman, Michelle</displayed-value><stored-value>349464</stored-value></pair>
-<pair><displayed-value>Givoly, Dan</displayed-value><stored-value>16160</stored-value></pair>
-
-<pair><displayed-value>Gode, Dan</displayed-value><stored-value>1131112</stored-value></pair>
-<pair><displayed-value>Gode, Dhanajay K.</displayed-value><stored-value>1131114</stored-value></pair>
-<pair><displayed-value>Gode, Dhananjay (Dan) K.</displayed-value><stored-value>19943</stored-value></pair>
-<pair><displayed-value>Goetz, Charles John</displayed-value><stored-value>23218</stored-value></pair>
-<pair><displayed-value>Goetzmann, William N.</displayed-value><stored-value>2309</stored-value></pair>
-<pair><displayed-value>Goldberg, Linda S.</displayed-value><stored-value>50703</stored-value></pair>
-
-<pair><displayed-value>Goldberg, Michael D.</displayed-value><stored-value>483755</stored-value></pair>
-<pair><displayed-value>Goldberg, Stephen R.</displayed-value><stored-value>55570</stored-value></pair>
-<pair><displayed-value>Golder, Peter N.</displayed-value><stored-value>634166</stored-value></pair>
-<pair><displayed-value>Goldfarb, Avi</displayed-value><stored-value>333590</stored-value></pair>
-<pair><displayed-value>Goldreich, David</displayed-value><stored-value>158371</stored-value></pair>
-<pair><displayed-value>Goldsmith, Kelly</displayed-value><stored-value>765756</stored-value></pair>
-
-<pair><displayed-value>Gonen, Ido</displayed-value><stored-value>1133329</stored-value></pair>
-<pair><displayed-value>Gong, Gang</displayed-value><stored-value>281662</stored-value></pair>
-<pair><displayed-value>Gonzalez-Eiras, Mart√ån</displayed-value><stored-value>250827</stored-value></pair>
-<pair><displayed-value>Goolsbee, Austan</displayed-value><stored-value>131421</stored-value></pair>
-<pair><displayed-value>Gopal, Ram D.</displayed-value><stored-value>370246</stored-value></pair>
-<pair><displayed-value>Gopikrishnan, Parameswaran</displayed-value><stored-value>347406</stored-value></pair>
-
-<pair><displayed-value>Gosden, John A.</displayed-value><stored-value>1143349</stored-value></pair>
-<pair><displayed-value>Gottesman, Aron A.</displayed-value><stored-value>224305</stored-value></pair>
-<pair><displayed-value>Govindaraj, Suresh</displayed-value><stored-value>20885</stored-value></pair>
-<pair><displayed-value>Gowrisankaran, Gautam</displayed-value><stored-value>31587</stored-value></pair>
-<pair><displayed-value>Goyenko, Ruslan</displayed-value><stored-value>352464</stored-value></pair>
-<pair><displayed-value>Graham, John D.</displayed-value><stored-value>616897</stored-value></pair>
-
-<pair><displayed-value>Grajek, Michal</displayed-value><stored-value>365888</stored-value></pair>
-<pair><displayed-value>Gramm, Wendy</displayed-value><stored-value>711506</stored-value></pair>
-<pair><displayed-value>Gravano, Luis</displayed-value><stored-value>1131957</stored-value></pair>
-<pair><displayed-value>Green, Clifton</displayed-value><stored-value>756399</stored-value></pair>
-<pair><displayed-value>Green, T. Clifton</displayed-value><stored-value>62092</stored-value></pair>
-<pair><displayed-value>Greenberg, Edward</displayed-value><stored-value>44962</stored-value></pair>
-
-<pair><displayed-value>Greene, William H.</displayed-value><stored-value>20759</stored-value></pair>
-<pair><displayed-value>Greenleaf, Eric</displayed-value><stored-value>83827</stored-value></pair>
-<pair><displayed-value>Greenstein, Shane M.</displayed-value><stored-value>31250</stored-value></pair>
-<pair><displayed-value>Greenwood, Jeremy</displayed-value><stored-value>80708</stored-value></pair>
-<pair><displayed-value>Greenwood, Robin Marc</displayed-value><stored-value>280104</stored-value></pair>
-<pair><displayed-value>Grigoras, Elena</displayed-value><stored-value>1346484</stored-value></pair>
-
-<pair><displayed-value>Grinblatt, Mark</displayed-value><stored-value>67458</stored-value></pair>
-<pair><displayed-value>Grishchenko, Olesya V.</displayed-value><stored-value>327449</stored-value></pair>
-<pair><displayed-value>Grody, Allan D.</displayed-value><stored-value>544794</stored-value></pair>
-<pair><displayed-value>Gross, Pamela HB</displayed-value><stored-value>1143315</stored-value></pair>
-<pair><displayed-value>Gruber, Marti J</displayed-value><stored-value>1148136</stored-value></pair>
-<pair><displayed-value>Gruber, Martin J.</displayed-value><stored-value>20851</stored-value></pair>
-
-<pair><displayed-value>Gruenfeld, Deborah H.</displayed-value><stored-value>327451</stored-value></pair>
-<pair><displayed-value>Grzybowski, Lukasz</displayed-value><stored-value>435230</stored-value></pair>
-<pair><displayed-value>Gu, Bin</displayed-value><stored-value>359302</stored-value></pair>
-<pair><displayed-value>Gu, Feng</displayed-value><stored-value>62791</stored-value></pair>
-<pair><displayed-value>Gudhus, Keith</displayed-value><stored-value>1133331</stored-value></pair>
-<pair><displayed-value>Gul, Ferdinand A.</displayed-value><stored-value>62751</stored-value></pair>
-
-<pair><displayed-value>Guner, Nezih</displayed-value><stored-value>213316</stored-value></pair>
-<pair><displayed-value>Gunn, Ronald R.</displayed-value><stored-value>53367</stored-value></pair>
-<pair><displayed-value>Guo, Hongtao</displayed-value><stored-value>112765</stored-value></pair>
-<pair><displayed-value>Guo, Hui</displayed-value><stored-value>295148</stored-value></pair>
-<pair><displayed-value>Guo, Re-Jin J.</displayed-value><stored-value>327185</stored-value></pair>
-<pair><displayed-value>Gupta, Alok</displayed-value><stored-value>714384</stored-value></pair>
-
-<pair><displayed-value>Gupta, Anurag</displayed-value><stored-value>136710</stored-value></pair>
-<pair><displayed-value>Gurvich, Itay</displayed-value><stored-value>1138823</stored-value></pair>
-<pair><displayed-value>Guthrie, Doug</displayed-value><stored-value>499370</stored-value></pair>
-<pair><displayed-value>Guti√àrrez-Hita, Carlos</displayed-value><stored-value>887473</stored-value></pair>
-<pair><displayed-value>G‚Äörleanu, Nicolae</displayed-value><stored-value>1056487</stored-value></pair>
-<pair><displayed-value>Habib, Michel A.</displayed-value><stored-value>45126</stored-value></pair>
-
-<pair><displayed-value>Hackel, Kenneth S.</displayed-value><stored-value>242330</stored-value></pair>
-<pair><displayed-value>Hahn, Jinyong</displayed-value><stored-value>145354</stored-value></pair>
-<pair><displayed-value>Hahn, Moritz</displayed-value><stored-value>1028581</stored-value></pair>
-<pair><displayed-value>Hahn, Robert W.</displayed-value><stored-value>153589</stored-value></pair>
-<pair><displayed-value>Hahs Flaharty, Linda J.</displayed-value><stored-value>143629</stored-value></pair>
-<pair><displayed-value>Hait, David J.</displayed-value><stored-value>44098</stored-value></pair>
-
-<pair><displayed-value>Haldeman, Robert</displayed-value><stored-value>136399</stored-value></pair>
-<pair><displayed-value>Hall, Robert E.</displayed-value><stored-value>45944</stored-value></pair>
-<pair><displayed-value>Hallman, Greg</displayed-value><stored-value>381712</stored-value></pair>
-<pair><displayed-value>Halov, Nikolay</displayed-value><stored-value>352876</stored-value></pair>
-<pair><displayed-value>Hamao, Yasushi</displayed-value><stored-value>22453</stored-value></pair>
-<pair><displayed-value>Handa, Puneet</displayed-value><stored-value>23118</stored-value></pair>
-
-<pair><displayed-value>Hann, Rebecca N.</displayed-value><stored-value>337331</stored-value></pair>
-<pair><displayed-value>Hansen, Gary D.</displayed-value><stored-value>55738</stored-value></pair>
-<pair><displayed-value>Harmantzis, Fotios</displayed-value><stored-value>389663</stored-value></pair>
-<pair><displayed-value>Harris, Lawrence</displayed-value><stored-value>17344</stored-value></pair>
-<pair><displayed-value>Hartzel, Jay C.</displayed-value><stored-value>1148483</stored-value></pair>
-<pair><displayed-value>Hartzell, Jay C.</displayed-value><stored-value>223681</stored-value></pair>
-
-<pair><displayed-value>Hasan, Iftekhar</displayed-value><stored-value>77268</stored-value></pair>
-<pair><displayed-value>Hasbrouck, Joel</displayed-value><stored-value>1043</stored-value></pair>
-<pair><displayed-value>Haselmann, Rainer F. H.</displayed-value><stored-value>452347</stored-value></pair>
-<pair><displayed-value>Hauge, Janice A.</displayed-value><stored-value>744979</stored-value></pair>
-<pair><displayed-value>Haugh, Martin</displayed-value><stored-value>327012</stored-value></pair>
-<pair><displayed-value>Hauser, Shmuel</displayed-value><stored-value>42203</stored-value></pair>
-
-<pair><displayed-value>Hausken, Kjell</displayed-value><stored-value>336843</stored-value></pair>
-<pair><displayed-value>Hausman, Jerry A.</displayed-value><stored-value>21519</stored-value></pair>
-<pair><displayed-value>Haw, In-Mu</displayed-value><stored-value>44524</stored-value></pair>
-<pair><displayed-value>Hayn, Carla</displayed-value><stored-value>62876</stored-value></pair>
-<pair><displayed-value>Hayt, Gregory S.</displayed-value><stored-value>145122</stored-value></pair>
-<pair><displayed-value>Hazlett, Thomas W.</displayed-value><stored-value>75418</stored-value></pair>
-
-<pair><displayed-value>He, Chuan</displayed-value><stored-value>116649</stored-value></pair>
-<pair><displayed-value>Heathcote, Jonathan</displayed-value><stored-value>327775</stored-value></pair>
-<pair><displayed-value>Hebert, William N.</displayed-value><stored-value>863273</stored-value></pair>
-<pair><displayed-value>Heider, Florian</displayed-value><stored-value>276127</stored-value></pair>
-<pair><displayed-value>Hellwig, Christian</displayed-value><stored-value>342765</stored-value></pair>
-<pair><displayed-value>Hendel, Igal E.</displayed-value><stored-value>151768</stored-value></pair>
-
-<pair><displayed-value>Hendry, David F.</displayed-value><stored-value>48860</stored-value></pair>
-<pair><displayed-value>Henriksen, Espen R.</displayed-value><stored-value>286514</stored-value></pair>
-<pair><displayed-value>Hens, Niel</displayed-value><stored-value>1147167</stored-value></pair>
-<pair><displayed-value>Hervas-Drane, Andres</displayed-value><stored-value>701983</stored-value></pair>
-<pair><displayed-value>Hess, James D.</displayed-value><stored-value>328083</stored-value></pair>
-<pair><displayed-value>Hill, Shawndra</displayed-value><stored-value>636819</stored-value></pair>
-
-<pair><displayed-value>Hiltz, Starr Roxanne</displayed-value><stored-value>1133791</stored-value></pair>
-<pair><displayed-value>Himmelberg, Charles P.</displayed-value><stored-value>22459</stored-value></pair>
-<pair><displayed-value>Hiraki, Takato</displayed-value><stored-value>67452</stored-value></pair>
-<pair><displayed-value>Ho, T.S.</displayed-value><stored-value>1151903</stored-value></pair>
-<pair><displayed-value>Ho, Teng-Suan</displayed-value><stored-value>1153787</stored-value></pair>
-<pair><displayed-value>Hochberg, Yael V.</displayed-value><stored-value>349530</stored-value></pair>
-
-<pair><displayed-value>Hogan, William W.</displayed-value><stored-value>99160</stored-value></pair>
-<pair><displayed-value>Hollie, Dana</displayed-value><stored-value>353583</stored-value></pair>
-<pair><displayed-value>Hollingsworth, Carl W.</displayed-value><stored-value>389362</stored-value></pair>
-<pair><displayed-value>Hollingworth, Bruce</displayed-value><stored-value>1132671</stored-value></pair>
-<pair><displayed-value>Holtz-Eakin, Douglas</displayed-value><stored-value>84888</stored-value></pair>
-<pair><displayed-value>Hong, Harrison G.</displayed-value><stored-value>342554</stored-value></pair>
-
-<pair><displayed-value>Hong, Seung Hyun</displayed-value><stored-value>105141</stored-value></pair>
-<pair><displayed-value>Honhon, Dorothee</displayed-value><stored-value>332071</stored-value></pair>
-<pair><displayed-value>Hopenhagn, Hugo</displayed-value><stored-value>1145829</stored-value></pair>
-<pair><displayed-value>Hopenhayn, Hugo A.</displayed-value><stored-value>47588</stored-value></pair>
-<pair><displayed-value>Hornstein, Abigail S.</displayed-value><stored-value>442067</stored-value></pair>
-<pair><displayed-value>Horowitz, Tina</displayed-value><stored-value>10397</stored-value></pair>
-
-<pair><displayed-value>Hortacsu, Ali</displayed-value><stored-value>229628</stored-value></pair>
-<pair><displayed-value>Horv¬∑th, Lajos</displayed-value><stored-value>571921</stored-value></pair>
-<pair><displayed-value>Houston, Joel F.</displayed-value><stored-value>16484</stored-value></pair>
-<pair><displayed-value>Howell, Jamie</displayed-value><stored-value>1146526</stored-value></pair>
-<pair><displayed-value>Hsieh, Mengchen</displayed-value><stored-value>582504</stored-value></pair>
-<pair><displayed-value>Hu, Jiawei</displayed-value><stored-value>272833</stored-value></pair>
-
-<pair><displayed-value>Hu, Jie</displayed-value><stored-value>1132255</stored-value></pair>
-<pair><displayed-value>Hu, Wei-Min</displayed-value><stored-value>854256</stored-value></pair>
-<pair><displayed-value>Huang, Jing-Zhi Jay</displayed-value><stored-value>739</stored-value></pair>
-<pair><displayed-value>Huang, Jing-zhi</displayed-value><stored-value>1148423</stored-value></pair>
-<pair><displayed-value>Huang, Ke-Wei</displayed-value><stored-value>555207</stored-value></pair>
-<pair><displayed-value>Huang, Ming</displayed-value><stored-value>1437</stored-value></pair>
-
-<pair><displayed-value>Huang, Rong</displayed-value><stored-value>346129</stored-value></pair>
-<pair><displayed-value>Huberman, Bernardo A.</displayed-value><stored-value>2040</stored-value></pair>
-<pair><displayed-value>Hughes, Alan</displayed-value><stored-value>178790</stored-value></pair>
-<pair><displayed-value>Hukkawala, Naeem</displayed-value><stored-value>1150542</stored-value></pair>
-<pair><displayed-value>Hull, John C.</displayed-value><stored-value>224834</stored-value></pair>
-<pair><displayed-value>Hummel, Robert A.</displayed-value><stored-value>1135974</stored-value></pair>
-
-<pair><displayed-value>Hunter, William Curt</displayed-value><stored-value>16301</stored-value></pair>
-<pair><displayed-value>Hurkens, J.P.M. (Sjaak)</displayed-value><stored-value>54300</stored-value></pair>
-<pair><displayed-value>Hurvich, C. M.</displayed-value><stored-value>1144330</stored-value></pair>
-<pair><displayed-value>Hurvich, Califford M.</displayed-value><stored-value>1147614</stored-value></pair>
-<pair><displayed-value>Hurvich, Clifford M.</displayed-value><stored-value>337443</stored-value></pair>
-<pair><displayed-value>Hylleberg, Svend</displayed-value><stored-value>25363</stored-value></pair>
-
-<pair><displayed-value>ICF, Yale</displayed-value><stored-value>223089</stored-value></pair>
-<pair><displayed-value>Ibbotson, Roger G.</displayed-value><stored-value>2315</stored-value></pair>
-<pair><displayed-value>Ibragimov, Rustam</displayed-value><stored-value>105146</stored-value></pair>
-<pair><displayed-value>Idicula, John</displayed-value><stored-value>416207</stored-value></pair>
-<pair><displayed-value>Igbaria, Magid</displayed-value><stored-value>1135980</stored-value></pair>
-<pair><displayed-value>Inderst, Roman</displayed-value><stored-value>190751</stored-value></pair>
-
-<pair><displayed-value>Institute, CFA</displayed-value><stored-value>362492</stored-value></pair>
-<pair><displayed-value>Ioannidis, Sotiris</displayed-value><stored-value>701845</stored-value></pair>
-<pair><displayed-value>Ipeirotis, Panagiotis G.</displayed-value><stored-value>586795</stored-value></pair>
-<pair><displayed-value>Ireland, Chris</displayed-value><stored-value>1133328</stored-value></pair>
-<pair><displayed-value>Isakowitz, Tomas</displayed-value><stored-value>1133776</stored-value></pair>
-<pair><displayed-value>Ivashina, Victoria</displayed-value><stored-value>380705</stored-value></pair>
-
-<pair><displayed-value>Ives, Blake</displayed-value><stored-value>1143421</stored-value></pair>
-<pair><displayed-value>Iyengar, Raghuram</displayed-value><stored-value>994217</stored-value></pair>
-<pair><displayed-value>Iyer, Ganesh</displayed-value><stored-value>328057</stored-value></pair>
-<pair><displayed-value>J. White, Lawrence</displayed-value><stored-value>1132674</stored-value></pair>
-<pair><displayed-value>Jackson, Susan</displayed-value><stored-value>80268</stored-value></pair>
-<pair><displayed-value>Jacob, Boudoukh</displayed-value><stored-value>1151305</stored-value></pair>
-
-<pair><displayed-value>Jacoby, Jacob</displayed-value><stored-value>231377</stored-value></pair>
-<pair><displayed-value>Jain, Alpa</displayed-value><stored-value>1131965</stored-value></pair>
-<pair><displayed-value>Jain, Shailendra Pratap</displayed-value><stored-value>19972</stored-value></pair>
-<pair><displayed-value>James, Paula</displayed-value><stored-value>1146524</stored-value></pair>
-<pair><displayed-value>Jamison, Mark A.</displayed-value><stored-value>415921</stored-value></pair>
-<pair><displayed-value>Janiszewski, Chris</displayed-value><stored-value>381831</stored-value></pair>
-
-<pair><displayed-value>Jankowitsch, Rainer</displayed-value><stored-value>327328</stored-value></pair>
-<pair><displayed-value>Jarke, Matthias</displayed-value><stored-value>1142951</stored-value></pair>
-<pair><displayed-value>Jeanblanc, Monique</displayed-value><stored-value>114711</stored-value></pair>
-<pair><displayed-value>Jegadeesh, Narasimhan</displayed-value><stored-value>16600</stored-value></pair>
-<pair><displayed-value>Jelassi, M. Tawfik</displayed-value><stored-value>1142080</stored-value></pair>
-<pair><displayed-value>Jenkinson, Tim</displayed-value><stored-value>33679</stored-value></pair>
-
-<pair><displayed-value>Jennings, Robert H.</displayed-value><stored-value>32971</stored-value></pair>
-<pair><displayed-value>Jensen, Christian S.</displayed-value><stored-value>1137345</stored-value></pair>
-<pair><displayed-value>Jeon, Doh-Shin</displayed-value><stored-value>332574</stored-value></pair>
-<pair><displayed-value>Jesper Christensen, Bent</displayed-value><stored-value>1153781</stored-value></pair>
-<pair><displayed-value>Jewitt, Ian D.</displayed-value><stored-value>81716</stored-value></pair>
-<pair><displayed-value>Jha, Shubin</displayed-value><stored-value>1148471</stored-value></pair>
-
-<pair><displayed-value>Jiang, Guolin</displayed-value><stored-value>400614</stored-value></pair>
-<pair><displayed-value>Jiang, Tianyi</displayed-value><stored-value>877455</stored-value></pair>
-<pair><displayed-value>Jing, Bing</displayed-value><stored-value>418497</stored-value></pair>
-<pair><displayed-value>Johar, Hardeep</displayed-value><stored-value>1141331</stored-value></pair>
-<pair><displayed-value>Johari, Ramesh</displayed-value><stored-value>661668</stored-value></pair>
-<pair><displayed-value>John, Klose</displayed-value><stored-value>1151906</stored-value></pair>
-
-<pair><displayed-value>John, Kose</displayed-value><stored-value>20854</stored-value></pair>
-<pair><displayed-value>John C., Driscoll</displayed-value><stored-value>1147162</stored-value></pair>
-<pair><displayed-value>Johnson, Kerri</displayed-value><stored-value>713458</stored-value></pair>
-<pair><displayed-value>Jones, Christopher</displayed-value><stored-value>1142303</stored-value></pair>
-<pair><displayed-value>Jorde, Thomas M.</displayed-value><stored-value>100249</stored-value></pair>
-<pair><displayed-value>Jorgensen, Bjorn N.</displayed-value><stored-value>62431</stored-value></pair>
-
-<pair><displayed-value>Joshi, Yogesh V.</displayed-value><stored-value>352270</stored-value></pair>
-<pair><displayed-value>Joskow, Paul L.</displayed-value><stored-value>21525</stored-value></pair>
-<pair><displayed-value>Jouini, Elyes</displayed-value><stored-value>259541</stored-value></pair>
-<pair><displayed-value>Jovanovic, Boyan</displayed-value><stored-value>63276</stored-value></pair>
-<pair><displayed-value>Ju, Nengjiu</displayed-value><stored-value>363</stored-value></pair>
-<pair><displayed-value>Jurgens, Amber</displayed-value><stored-value>714395</stored-value></pair>
-
-<pair><displayed-value>Kacperczyk, Marcin T.</displayed-value><stored-value>301912</stored-value></pair>
-<pair><displayed-value>Kadam, Ashay</displayed-value><stored-value>336363</stored-value></pair>
-<pair><displayed-value>Kahan, Marcel</displayed-value><stored-value>17626</stored-value></pair>
-<pair><displayed-value>Kahn, Alfred E.</displayed-value><stored-value>81458</stored-value></pair>
-<pair><displayed-value>Kallal, Hedi</displayed-value><stored-value>71825</stored-value></pair>
-<pair><displayed-value>Kallal, H√àdi</displayed-value><stored-value>1151307</stored-value></pair>
-
-<pair><displayed-value>Kallberg, Jarl G. (Jerry)</displayed-value><stored-value>20858</stored-value></pair>
-<pair><displayed-value>Kalt, Joseph P.</displayed-value><stored-value>242970</stored-value></pair>
-<pair><displayed-value>Kambhu, John</displayed-value><stored-value>99021</stored-value></pair>
-<pair><displayed-value>Kambil, Ajit</displayed-value><stored-value>1133783</stored-value></pair>
-<pair><displayed-value>Kamis, Arnold</displayed-value><stored-value>419898</stored-value></pair>
-<pair><displayed-value>Kaniel, Ron</displayed-value><stored-value>48389</stored-value></pair>
-
-<pair><displayed-value>Kant, Tushar</displayed-value><stored-value>1334984</stored-value></pair>
-<pair><displayed-value>Kaplan, Edward H.</displayed-value><stored-value>281819</stored-value></pair>
-<pair><displayed-value>Karamti, Chiraz</displayed-value><stored-value>883410</stored-value></pair>
-<pair><displayed-value>Karasek, Robert A., Jr.</displayed-value><stored-value>1143338</stored-value></pair>
-<pair><displayed-value>Karlin, Brenda</displayed-value><stored-value>1334983</stored-value></pair>
-<pair><displayed-value>Katsamakas, Evangelos</displayed-value><stored-value>412514</stored-value></pair>
-
-<pair><displayed-value>Katz, Barbara G.</displayed-value><stored-value>17629</stored-value></pair>
-<pair><displayed-value>Kauffman, Rob</displayed-value><stored-value>470142</stored-value></pair>
-<pair><displayed-value>Kauffman, Robert J.</displayed-value><stored-value>920013</stored-value></pair>
-<pair><displayed-value>Kauffman, Robert</displayed-value><stored-value>1142289</stored-value></pair>
-<pair><displayed-value>Kaul, Aditya</displayed-value><stored-value>107869</stored-value></pair>
-<pair><displayed-value>Kaushik, P.D.</displayed-value><stored-value>339448</stored-value></pair>
-
-<pair><displayed-value>Kavajecz, Kenneth A.</displayed-value><stored-value>31959</stored-value></pair>
-<pair><displayed-value>Keane, Michael P.</displayed-value><stored-value>31618</stored-value></pair>
-<pair><displayed-value>Kedem, Zvi M.</displayed-value><stored-value>547044</stored-value></pair>
-<pair><displayed-value>Kedia, Semi</displayed-value><stored-value>1148131</stored-value></pair>
-<pair><displayed-value>Kedia, Simi</displayed-value><stored-value>66529</stored-value></pair>
-<pair><displayed-value>Kehoe, Conor</displayed-value><stored-value>977184</stored-value></pair>
-
-<pair><displayed-value>Keisler, H. Jerome</displayed-value><stored-value>265268</stored-value></pair>
-<pair><displayed-value>Kelly, Bryan T.</displayed-value><stored-value>759326</stored-value></pair>
-<pair><displayed-value>Kemerer, Chris F.</displayed-value><stored-value>409699</stored-value></pair>
-<pair><displayed-value>Kendall, Jake</displayed-value><stored-value>409729</stored-value></pair>
-<pair><displayed-value>Kesavan, Saravanan</displayed-value><stored-value>482582</stored-value></pair>
-<pair><displayed-value>Kilian, Lutz</displayed-value><stored-value>50236</stored-value></pair>
-
-<pair><displayed-value>Kim, Byung-Cheol</displayed-value><stored-value>841716</stored-value></pair>
-<pair><displayed-value>Kim, Chansog Francis</displayed-value><stored-value>223537</stored-value></pair>
-<pair><displayed-value>Kim, Dong Won</displayed-value><stored-value>104390</stored-value></pair>
-<pair><displayed-value>Kim, Dongcheol</displayed-value><stored-value>17898</stored-value></pair>
-<pair><displayed-value>Kim, Haeng Ran</displayed-value><stored-value>426792</stored-value></pair>
-<pair><displayed-value>Kim, Harold Y.</displayed-value><stored-value>120188</stored-value></pair>
-
-<pair><displayed-value>Kim, Jiyoung</displayed-value><stored-value>701994</stored-value></pair>
-<pair><displayed-value>Kim, Myungsun</displayed-value><stored-value>395795</stored-value></pair>
-<pair><displayed-value>Kim, Sung K.</displayed-value><stored-value>1143442</stored-value></pair>
-<pair><displayed-value>Kim, Yongbeom</displayed-value><stored-value>1133780</stored-value></pair>
-<pair><displayed-value>Kimbrough, Steven O.</displayed-value><stored-value>453197</stored-value></pair>
-<pair><displayed-value>Kind, Axel H.</displayed-value><stored-value>276535</stored-value></pair>
-
-<pair><displayed-value>Kirsh, Amir</displayed-value><stored-value>295189</stored-value></pair>
-<pair><displayed-value>Kishore, Vellore</displayed-value><stored-value>136208</stored-value></pair>
-<pair><displayed-value>Klapper, Leora F.</displayed-value><stored-value>1963</stored-value></pair>
-<pair><displayed-value>Klein, April</displayed-value><stored-value>17575</stored-value></pair>
-<pair><displayed-value>Kleindorfer, Paul R.</displayed-value><stored-value>124201</stored-value></pair>
-<pair><displayed-value>Klimenko, Mikhail M.</displayed-value><stored-value>141241</stored-value></pair>
-
-<pair><displayed-value>Knittel, Christopher R.</displayed-value><stored-value>200291</stored-value></pair>
-<pair><displayed-value>Knopf, John D.</displayed-value><stored-value>912772</stored-value></pair>
-<pair><displayed-value>Koch, Juergen</displayed-value><stored-value>1143343</stored-value></pair>
-<pair><displayed-value>Koch, Jurgen</displayed-value><stored-value>1143320</stored-value></pair>
-<pair><displayed-value>Koehl, Pierre-F.</displayed-value><stored-value>1151911</stored-value></pair>
-<pair><displayed-value>Koijen, Ralph S. J.</displayed-value><stored-value>374406</stored-value></pair>
-
-<pair><displayed-value>Konings, Jozef</displayed-value><stored-value>87410</stored-value></pair>
-<pair><displayed-value>Konsynski, Benn</displayed-value><stored-value>349223</stored-value></pair>
-<pair><displayed-value>Koopman, Siem Jan</displayed-value><stored-value>137911</stored-value></pair>
-<pair><displayed-value>Kornhauser, Lewis A.</displayed-value><stored-value>119221</stored-value></pair>
-<pair><displayed-value>Kotha, Suresh</displayed-value><stored-value>17633</stored-value></pair>
-<pair><displayed-value>Kothari, S.P.</displayed-value><stored-value>17425</stored-value></pair>
-
-<pair><displayed-value>Koticha, Apoorva</displayed-value><stored-value>15977</stored-value></pair>
-<pair><displayed-value>Kotlikoff, Laurence J.</displayed-value><stored-value>44751</stored-value></pair>
-<pair><displayed-value>Koufaris, Marios</displayed-value><stored-value>447162</stored-value></pair>
-<pair><displayed-value>Krainer, John</displayed-value><stored-value>295386</stored-value></pair>
-<pair><displayed-value>Krause, Jurgen</displayed-value><stored-value>1143319</stored-value></pair>
-<pair><displayed-value>Krauss, Lindsay</displayed-value><stored-value>844278</stored-value></pair>
-
-<pair><displayed-value>Krauss, Nicolas A.</displayed-value><stored-value>568148</stored-value></pair>
-<pair><displayed-value>Kraussa, Nicolas</displayed-value><stored-value>1155487</stored-value></pair>
-<pair><displayed-value>Kraut, Robert E.</displayed-value><stored-value>332747</stored-value></pair>
-<pair><displayed-value>Krcmar, Helmut</displayed-value><stored-value>1142966</stored-value></pair>
-<pair><displayed-value>Kremer, Ilan</displayed-value><stored-value>302954</stored-value></pair>
-<pair><displayed-value>Kretschmer, Tobias</displayed-value><stored-value>350496</stored-value></pair>
-
-<pair><displayed-value>Kreuger, Dirk</displayed-value><stored-value>1146525</stored-value></pair>
-<pair><displayed-value>Kriebel, Charles H.</displayed-value><stored-value>370977</stored-value></pair>
-<pair><displayed-value>Krinsky, Itzhak</displayed-value><stored-value>161621</stored-value></pair>
-<pair><displayed-value>Krishnamurthy, Arvind</displayed-value><stored-value>141171</stored-value></pair>
-<pair><displayed-value>Krishnan, Ramayya</displayed-value><stored-value>269035</stored-value></pair>
-<pair><displayed-value>Krolzig, Martin</displayed-value><stored-value>1151303</stored-value></pair>
-
-<pair><displayed-value>Krueger, Dirk</displayed-value><stored-value>92354</stored-value></pair>
-<pair><displayed-value>Kruger, Justin</displayed-value><stored-value>712076</stored-value></pair>
-<pair><displayed-value>Krugman, Paul R.</displayed-value><stored-value>21531</stored-value></pair>
-<pair><displayed-value>Kumar, Akhi</displayed-value><stored-value>1133975</stored-value></pair>
-<pair><displayed-value>Kumar, Alok</displayed-value><stored-value>56396</stored-value></pair>
-<pair><displayed-value>Kumar, Alok</displayed-value><stored-value>1153497</stored-value></pair>
-
-<pair><displayed-value>Kumar, Rachna</displayed-value><stored-value>1141328</stored-value></pair>
-<pair><displayed-value>Kumar, V.</displayed-value><stored-value>994221</stored-value></pair>
-<pair><displayed-value>Kumaraswamy, A.</displayed-value><stored-value>1142083</stored-value></pair>
-<pair><displayed-value>Kumaraswamy, Arun</displayed-value><stored-value>678570</stored-value></pair>
-<pair><displayed-value>Kumbhakar, Subal C.</displayed-value><stored-value>185128</stored-value></pair>
-<pair><displayed-value>Kuper, Gabriel M.</displayed-value><stored-value>1141336</stored-value></pair>
-
-<pair><displayed-value>Kwoka Jr., John E.</displayed-value><stored-value>1146531</stored-value></pair>
-<pair><displayed-value>L. Silber, William</displayed-value><stored-value>1147622</stored-value></pair>
-<pair><displayed-value>L. Silber*, William</displayed-value><stored-value>1147161</stored-value></pair>
-<pair><displayed-value>LEE-WINGATE, SOOYEON NIKKI</displayed-value><stored-value>712095</stored-value></pair>
-<pair><displayed-value>LaBarbera, Priscilla A.</displayed-value><stored-value>1143355</stored-value></pair>
-<pair><displayed-value>LaBarbera, Priscilla Ann</displayed-value><stored-value>1141320</stored-value></pair>
-
-<pair><displayed-value>Labys, Paul</displayed-value><stored-value>151739</stored-value></pair>
-<pair><displayed-value>Lagos, Ricardo</displayed-value><stored-value>247872</stored-value></pair>
-<pair><displayed-value>Laibson, David I.</displayed-value><stored-value>20341</stored-value></pair>
-<pair><displayed-value>Lajbcygier, Paul</displayed-value><stored-value>809452</stored-value></pair>
-<pair><displayed-value>Lakner, Peter</displayed-value><stored-value>336364</stored-value></pair>
-<pair><displayed-value>Lally, Laura</displayed-value><stored-value>1135982</stored-value></pair>
-
-<pair><displayed-value>Lambert-Mogiliansky, Ariane</displayed-value><stored-value>1131956</stored-value></pair>
-<pair><displayed-value>Lambrecht, Anja</displayed-value><stored-value>617552</stored-value></pair>
-<pair><displayed-value>Landier, Augustin</displayed-value><stored-value>262766</stored-value></pair>
-<pair><displayed-value>Landskroner, Yoram</displayed-value><stored-value>94361</stored-value></pair>
-<pair><displayed-value>Lang, Gabriel</displayed-value><stored-value>1147615</stored-value></pair>
-<pair><displayed-value>Langberg, Nisan</displayed-value><stored-value>118208</stored-value></pair>
-
-<pair><displayed-value>Lange, Jeffrey</displayed-value><stored-value>239017</stored-value></pair>
-<pair><displayed-value>Lange, Joe</displayed-value><stored-value>58279</stored-value></pair>
-<pair><displayed-value>Laudon, Kenneth</displayed-value><stored-value>1133784</stored-value></pair>
-<pair><displayed-value>Lauterbach, Beni</displayed-value><stored-value>54391</stored-value></pair>
-<pair><displayed-value>Lave, Lester B.</displayed-value><stored-value>259026</stored-value></pair>
-<pair><displayed-value>Lazer, Ron</displayed-value><stored-value>276745</stored-value></pair>
-
-<pair><displayed-value>Le, Anh</displayed-value><stored-value>568157</stored-value></pair>
-<pair><displayed-value>LeBaron, Blake D.</displayed-value><stored-value>1108</stored-value></pair>
-<pair><displayed-value>Leaver, Clare</displayed-value><stored-value>637144</stored-value></pair>
-<pair><displayed-value>Lederman, Mara</displayed-value><stored-value>547010</stored-value></pair>
-<pair><displayed-value>Lee, Cassia</displayed-value><stored-value>658905</stored-value></pair>
-<pair><displayed-value>Lee, Chi-Wen Jevons</displayed-value><stored-value>1152397</stored-value></pair>
-
-<pair><displayed-value>Lee, Gary G.J.</displayed-value><stored-value>143908</stored-value></pair>
-<pair><displayed-value>Lee, Jae B.</displayed-value><stored-value>1143451</stored-value></pair>
-<pair><displayed-value>Lee, Jeho</displayed-value><stored-value>473212</stored-value></pair>
-<pair><displayed-value>Lee, Kyung-seol</displayed-value><stored-value>342729</stored-value></pair>
-<pair><displayed-value>Lee, Robin S.</displayed-value><stored-value>858572</stored-value></pair>
-<pair><displayed-value>Lehr, William</displayed-value><stored-value>1147509</stored-value></pair>
-
-<pair><displayed-value>Lerman, Alina</displayed-value><stored-value>779914</stored-value></pair>
-<pair><displayed-value>Lertwachara, Kaveepan</displayed-value><stored-value>370248</stored-value></pair>
-<pair><displayed-value>Leshno, Moshe</displayed-value><stored-value>1141333</stored-value></pair>
-<pair><displayed-value>Lesmond, David A.</displayed-value><stored-value>185491</stored-value></pair>
-<pair><displayed-value>Lettau, Martin</displayed-value><stored-value>58454</stored-value></pair>
-<pair><displayed-value>Lev, Baruch Itamar</displayed-value><stored-value>20898</stored-value></pair>
-
-<pair><displayed-value>Levecq, Hugues</displayed-value><stored-value>28211</stored-value></pair>
-<pair><displayed-value>Levich, Richard M.</displayed-value><stored-value>20862</stored-value></pair>
-<pair><displayed-value>Levina, Natalia</displayed-value><stored-value>327560</stored-value></pair>
-<pair><displayed-value>Levinthal, Daniel A.</displayed-value><stored-value>266292</stored-value></pair>
-<pair><displayed-value>Levy, Amnon</displayed-value><stored-value>17635</stored-value></pair>
-<pair><displayed-value>Levy, Amnon</displayed-value><stored-value>383436</stored-value></pair>
-
-<pair><displayed-value>Levy, Nino</displayed-value><stored-value>365032</stored-value></pair>
-<pair><displayed-value>Lewis, Barry L.</displayed-value><stored-value>217991</stored-value></pair>
-<pair><displayed-value>Lewis, Melissa Fay</displayed-value><stored-value>393822</stored-value></pair>
-<pair><displayed-value>Li, Bob</displayed-value><stored-value>653614</stored-value></pair>
-<pair><displayed-value>Li, Kai NMI3</displayed-value><stored-value>328664</stored-value></pair>
-<pair><displayed-value>Li, Kefei</displayed-value><stored-value>337442</stored-value></pair>
-
-<pair><displayed-value>Li, Lexin</displayed-value><stored-value>1147164</stored-value></pair>
-<pair><displayed-value>Li, Li NMI2</displayed-value><stored-value>145986</stored-value></pair>
-<pair><displayed-value>Li, Siyi</displayed-value><stored-value>361943</stored-value></pair>
-<pair><displayed-value>Liang, Bing</displayed-value><stored-value>1069</stored-value></pair>
-<pair><displayed-value>Liang, Weijian</displayed-value><stored-value>686631</stored-value></pair>
-<pair><displayed-value>Lianos, Ioannis</displayed-value><stored-value>565608</stored-value></pair>
-
-<pair><displayed-value>Liao, Elena</displayed-value><stored-value>428974</stored-value></pair>
-<pair><displayed-value>Liao, Hsien-Hsing</displayed-value><stored-value>491810</stored-value></pair>
-<pair><displayed-value>Lichtman, Douglas Gary</displayed-value><stored-value>130905</stored-value></pair>
-<pair><displayed-value>Lilien, Steven</displayed-value><stored-value>1131108</stored-value></pair>
-<pair><displayed-value>Lilien, Steven B.</displayed-value><stored-value>62452</stored-value></pair>
-<pair><displayed-value>Liljenquist, Katie</displayed-value><stored-value>118215</stored-value></pair>
-
-<pair><displayed-value>Lin, Valdimir Ya.</displayed-value><stored-value>1141334</stored-value></pair>
-<pair><displayed-value>Lindahl, Frederick W.</displayed-value><stored-value>16626</stored-value></pair>
-<pair><displayed-value>Linder, Diane C.</displayed-value><stored-value>358088</stored-value></pair>
-<pair><displayed-value>Lindner, Ines</displayed-value><stored-value>486858</stored-value></pair>
-<pair><displayed-value>Linnemann, Volker</displayed-value><stored-value>1143310</stored-value></pair>
-<pair><displayed-value>Litan, Robert E.</displayed-value><stored-value>179991</stored-value></pair>
-
-<pair><displayed-value>Litov, Lubomir P.</displayed-value><stored-value>327450</stored-value></pair>
-<pair><displayed-value>Littman, Michael L.</displayed-value><stored-value>1133778</stored-value></pair>
-<pair><displayed-value>Liu, Bing</displayed-value><stored-value>1132254</stored-value></pair>
-<pair><displayed-value>Liu, Charles Z.</displayed-value><stored-value>713292</stored-value></pair>
-<pair><displayed-value>Liu, Chi-Chun</displayed-value><stored-value>534381</stored-value></pair>
-<pair><displayed-value>Liu, Crocker H.</displayed-value><stored-value>20864</stored-value></pair>
-
-<pair><displayed-value>Liu, Debin</displayed-value><stored-value>701914</stored-value></pair>
-<pair><displayed-value>Liu, Qihong</displayed-value><stored-value>398784</stored-value></pair>
-<pair><displayed-value>Livnat, Joshua</displayed-value><stored-value>20900</stored-value></pair>
-<pair><displayed-value>Lizzeri, Alessandro</displayed-value><stored-value>150888</stored-value></pair>
-<pair><displayed-value>Ljungqvist, Alexander</displayed-value><stored-value>33683</stored-value></pair>
-<pair><displayed-value>Llorente, Guillermo</displayed-value><stored-value>1149011</stored-value></pair>
-
-<pair><displayed-value>Lobel, Ilan</displayed-value><stored-value>1033603</stored-value></pair>
-<pair><displayed-value>Lochovsky, F.H.</displayed-value><stored-value>1143347</stored-value></pair>
-<pair><displayed-value>Lochstoer, Lars A.</displayed-value><stored-value>337715</stored-value></pair>
-<pair><displayed-value>Longawa, Vicky M.</displayed-value><stored-value>362396</stored-value></pair>
-<pair><displayed-value>Lookabaugh, Tom</displayed-value><stored-value>417769</stored-value></pair>
-<pair><displayed-value>Lopomo, Giuseppe</displayed-value><stored-value>20777</stored-value></pair>
-
-<pair><displayed-value>Lorsch, Jay W.</displayed-value><stored-value>38965</stored-value></pair>
-<pair><displayed-value>Lothian, James R.</displayed-value><stored-value>83594</stored-value></pair>
-<pair><displayed-value>Lovell, C.A. Knox</displayed-value><stored-value>240400</stored-value></pair>
-<pair><displayed-value>Lozano, Ana</displayed-value><stored-value>1152958</stored-value></pair>
-<pair><displayed-value>Lozano-Vivas, Ana</displayed-value><stored-value>1152952</stored-value></pair>
-<pair><displayed-value>Lu, Yang</displayed-value><stored-value>1148867</stored-value></pair>
-
-<pair><displayed-value>Lu, Yi NMI1</displayed-value><stored-value>361957</stored-value></pair>
-<pair><displayed-value>Lucas, Andr√à</displayed-value><stored-value>1151296</stored-value></pair>
-<pair><displayed-value>Lucas, Henry C.</displayed-value><stored-value>415752</stored-value></pair>
-<pair><displayed-value>Lucas, Henry Jr.</displayed-value><stored-value>1135981</stored-value></pair>
-<pair><displayed-value>Lucas Jr., Henry C.</displayed-value><stored-value>1137351</stored-value></pair>
-<pair><displayed-value>Ludvigson, Sydney C.</displayed-value><stored-value>66250</stored-value></pair>
-
-<pair><displayed-value>Lunde, Asger</displayed-value><stored-value>25449</stored-value></pair>
-<pair><displayed-value>Lurie, Nicholas H.</displayed-value><stored-value>421541</stored-value></pair>
-<pair><displayed-value>Lustig, Hanno N.</displayed-value><stored-value>295977</stored-value></pair>
-<pair><displayed-value>Lutter, Randall</displayed-value><stored-value>237989</stored-value></pair>
-<pair><displayed-value>Lynch, Anthony W.</displayed-value><stored-value>20866</stored-value></pair>
-<pair><displayed-value>Lynch, Eileen M.</displayed-value><stored-value>1143348</stored-value></pair>
-
-<pair><displayed-value>Lynn, Stephen</displayed-value><stored-value>115001</stored-value></pair>
-<pair><displayed-value>Lys, Thomas Z.</displayed-value><stored-value>23037</stored-value></pair>
-<pair><displayed-value>Lyytinen, Kalle J.</displayed-value><stored-value>583866</stored-value></pair>
-<pair><displayed-value>M. Gallo, Giampiero</displayed-value><stored-value>1147620</stored-value></pair>
-<pair><displayed-value>M. Levich, Richard</displayed-value><stored-value>1147611</stored-value></pair>
-<pair><displayed-value>M. Mueller, Holger</displayed-value><stored-value>1147610</stored-value></pair>
-
-<pair><displayed-value>MA, Pai-chun</displayed-value><stored-value>1142963</stored-value></pair>
-<pair><displayed-value>MacAvoy, Paul W.</displayed-value><stored-value>63054</stored-value></pair>
-<pair><displayed-value>MacDonald, Glenn M.</displayed-value><stored-value>20012</stored-value></pair>
-<pair><displayed-value>MacLeod, W. Bentley</displayed-value><stored-value>832328</stored-value></pair>
-<pair><displayed-value>Macdonald, Ben</displayed-value><stored-value>1133325</stored-value></pair>
-<pair><displayed-value>Macskassy, Sofus</displayed-value><stored-value>660162</stored-value></pair>
-
-<pair><displayed-value>Madhavan, Ananth</displayed-value><stored-value>17360</stored-value></pair>
-<pair><displayed-value>Madhavan, R.</displayed-value><stored-value>1142069</stored-value></pair>
-<pair><displayed-value>Madhavan, Raghav K.</displayed-value><stored-value>1142072</stored-value></pair>
-<pair><displayed-value>Magee, Joseph Carl</displayed-value><stored-value>341625</stored-value></pair>
-<pair><displayed-value>Maggi, Giovanni</displayed-value><stored-value>74188</stored-value></pair>
-<pair><displayed-value>Mahajan, Shalini</displayed-value><stored-value>1133334</stored-value></pair>
-
-<pair><displayed-value>Mahanti, Sriketan</displayed-value><stored-value>457236</stored-value></pair>
-<pair><displayed-value>Mahanti, Sriketan</displayed-value><stored-value>854186</stored-value></pair>
-<pair><displayed-value>Maheswaran, Durairaj</displayed-value><stored-value>79840</stored-value></pair>
-<pair><displayed-value>Mahoney, Paul G.</displayed-value><stored-value>44562</stored-value></pair>
-<pair><displayed-value>Maindiratta, Ajay</displayed-value><stored-value>20902</stored-value></pair>
-<pair><displayed-value>Maitland, Carleen</displayed-value><stored-value>395832</stored-value></pair>
-
-<pair><displayed-value>Maitra, Pushkar</displayed-value><stored-value>52487</stored-value></pair>
-<pair><displayed-value>Majumdar, Makul</displayed-value><stored-value>1133348</stored-value></pair>
-<pair><displayed-value>Majumdar, Mukul</displayed-value><stored-value>81460</stored-value></pair>
-<pair><displayed-value>Malik, Gaurav</displayed-value><stored-value>1148138</stored-value></pair>
-<pair><displayed-value>Malkiel, Burton G.</displayed-value><stored-value>17846</stored-value></pair>
-<pair><displayed-value>Mallik, Gaurav</displayed-value><stored-value>457254</stored-value></pair>
-
-<pair><displayed-value>Malloy, Christopher J.</displayed-value><stored-value>97668</stored-value></pair>
-<pair><displayed-value>Malone, Rich</displayed-value><stored-value>1142071</stored-value></pair>
-<pair><displayed-value>Man-Cho So, Anthony</displayed-value><stored-value>1147155</stored-value></pair>
-<pair><displayed-value>Mancini, Cecilia</displayed-value><stored-value>649903</stored-value></pair>
-<pair><displayed-value>Mancini, Loriano</displayed-value><stored-value>345154</stored-value></pair>
-<pair><displayed-value>Mandelbaum, Avishai</displayed-value><stored-value>1143353</stored-value></pair>
-
-<pair><displayed-value>Manganelli, Simone</displayed-value><stored-value>196912</stored-value></pair>
-<pair><displayed-value>Mann, Christopher</displayed-value><stored-value>516501</stored-value></pair>
-<pair><displayed-value>Mann, Christopher</displayed-value><stored-value>1148838</stored-value></pair>
-<pair><displayed-value>Manso, Gustavo</displayed-value><stored-value>348878</stored-value></pair>
-<pair><displayed-value>Mantena, Ravi</displayed-value><stored-value>380045</stored-value></pair>
-<pair><displayed-value>Marcus, Alan J.</displayed-value><stored-value>25781</stored-value></pair>
-
-<pair><displayed-value>Marimon, Ramon</displayed-value><stored-value>30662</stored-value></pair>
-<pair><displayed-value>Marin, Dalia</displayed-value><stored-value>48052</stored-value></pair>
-<pair><displayed-value>Marisetty, Vijaya B.</displayed-value><stored-value>328926</stored-value></pair>
-<pair><displayed-value>Mark, Gideon</displayed-value><stored-value>560800</stored-value></pair>
-<pair><displayed-value>Mark, Robert M.</displayed-value><stored-value>1137369</stored-value></pair>
-<pair><displayed-value>Markus, M. Lynne</displayed-value><stored-value>1135968</stored-value></pair>
-
-<pair><displayed-value>Marquardt, Carol</displayed-value><stored-value>47028</stored-value></pair>
-<pair><displayed-value>Marr, Kenneth</displayed-value><stored-value>1142078</stored-value></pair>
-<pair><displayed-value>Marr, Kenneth L.</displayed-value><stored-value>1135959</stored-value></pair>
-<pair><displayed-value>Marsden, James R.</displayed-value><stored-value>370247</stored-value></pair>
-<pair><displayed-value>Marston, Felicia C.</displayed-value><stored-value>252672</stored-value></pair>
-<pair><displayed-value>Marti, Subrahmanyam</displayed-value><stored-value>1147165</stored-value></pair>
-
-<pair><displayed-value>Martinez-Jerez, Francisco de Asis</displayed-value><stored-value>79593</stored-value></pair>
-<pair><displayed-value>Martins, Luis L.</displayed-value><stored-value>1137354</stored-value></pair>
-<pair><displayed-value>Mashruwala, Raj</displayed-value><stored-value>365910</stored-value></pair>
-<pair><displayed-value>Masset, Pierre</displayed-value><stored-value>1150541</stored-value></pair>
-<pair><displayed-value>Massoud, Nadia</displayed-value><stored-value>110449</stored-value></pair>
-<pair><displayed-value>Massoud, Nadia Ziad</displayed-value><stored-value>1151901</stored-value></pair>
-
-<pair><displayed-value>Mathiassen, Lars</displayed-value><stored-value>1142065</stored-value></pair>
-<pair><displayed-value>Mayo, John W.</displayed-value><stored-value>224924</stored-value></pair>
-<pair><displayed-value>McAllester, David</displayed-value><stored-value>1142081</stored-value></pair>
-<pair><displayed-value>McAllister, Patrick</displayed-value><stored-value>1150427</stored-value></pair>
-<pair><displayed-value>McAndrews, James</displayed-value><stored-value>44684</stored-value></pair>
-<pair><displayed-value>McCabe, Mark J.</displayed-value><stored-value>357883</stored-value></pair>
-
-<pair><displayed-value>McCracken, Paul W.</displayed-value><stored-value>713997</stored-value></pair>
-<pair><displayed-value>McCullough, Bruce D.</displayed-value><stored-value>328094</stored-value></pair>
-<pair><displayed-value>McDowell, Jhon</displayed-value><stored-value>1147628</stored-value></pair>
-<pair><displayed-value>McDowell, John M.</displayed-value><stored-value>276492</stored-value></pair>
-<pair><displayed-value>McVay, Monte</displayed-value><stored-value>1143306</stored-value></pair>
-<pair><displayed-value>McVay, Sarah E.</displayed-value><stored-value>333097</stored-value></pair>
-
-<pair><displayed-value>Mcskassy, Sofus</displayed-value><stored-value>1131947</stored-value></pair>
-<pair><displayed-value>Mehran, Hamid</displayed-value><stored-value>15840</stored-value></pair>
-<pair><displayed-value>Mei, Jiangping</displayed-value><stored-value>1148433</stored-value></pair>
-<pair><displayed-value>Mei, Jianping</displayed-value><stored-value>17637</stored-value></pair>
-<pair><displayed-value>Mei, Jianping (J.P.)</displayed-value><stored-value>1152392</stored-value></pair>
-<pair><displayed-value>Mendelson, Haim</displayed-value><stored-value>85588</stored-value></pair>
-
-<pair><displayed-value>Mendenhall, Richard R.</displayed-value><stored-value>16859</stored-value></pair>
-<pair><displayed-value>Menicucci, Domenico</displayed-value><stored-value>332952</stored-value></pair>
-<pair><displayed-value>Menkveld, Albert J.</displayed-value><stored-value>49904</stored-value></pair>
-<pair><displayed-value>Menon, Geeta</displayed-value><stored-value>505839</stored-value></pair>
-<pair><displayed-value>Merrick, John J.</displayed-value><stored-value>327360</stored-value></pair>
-<pair><displayed-value>Merrick, Jr. John J.</displayed-value><stored-value>1152394</stored-value></pair>
-
-<pair><displayed-value>Merten, Alan C.</displayed-value><stored-value>1143305</stored-value></pair>
-<pair><displayed-value>Merten, Alan G.</displayed-value><stored-value>1143308</stored-value></pair>
-<pair><displayed-value>Meyvis, Tom</displayed-value><stored-value>713366</stored-value></pair>
-<pair><displayed-value>Meza, Sergio</displayed-value><stored-value>116911</stored-value></pair>
-<pair><displayed-value>Mezias, John M.</displayed-value><stored-value>345905</stored-value></pair>
-<pair><displayed-value>Michaels, Robert J.</displayed-value><stored-value>246977</stored-value></pair>
-
-<pair><displayed-value>Michaely, Roni</displayed-value><stored-value>16133</stored-value></pair>
-<pair><displayed-value>Michielse, Ken</displayed-value><stored-value>1143453</stored-value></pair>
-<pair><displayed-value>Milgrom, Paul R.</displayed-value><stored-value>22848</stored-value></pair>
-<pair><displayed-value>Miller, James C.</displayed-value><stored-value>65908</stored-value></pair>
-<pair><displayed-value>Miravete, Eugenio J.</displayed-value><stored-value>21475</stored-value></pair>
-<pair><displayed-value>Mistry, Abhishek</displayed-value><stored-value>1222846</stored-value></pair>
-
-<pair><displayed-value>Mitra, Prasenjit</displayed-value><stored-value>551429</stored-value></pair>
-<pair><displayed-value>Mohanram, Partha S.</displayed-value><stored-value>152633</stored-value></pair>
-<pair><displayed-value>Mojarad, Sarah M</displayed-value><stored-value>1195265</stored-value></pair>
-<pair><displayed-value>Moloche, Guillermo</displayed-value><stored-value>347909</stored-value></pair>
-<pair><displayed-value>Morck, Randall</displayed-value><stored-value>71368</stored-value></pair>
-<pair><displayed-value>Morey, Richard R</displayed-value><stored-value>430596</stored-value></pair>
-
-<pair><displayed-value>Morrin, Maureen</displayed-value><stored-value>231381</stored-value></pair>
-<pair><displayed-value>Morris, Anthony</displayed-value><stored-value>571288</stored-value></pair>
-<pair><displayed-value>Morwitz, Vicki</displayed-value><stored-value>95189</stored-value></pair>
-<pair><displayed-value>Moser, James T.</displayed-value><stored-value>16296</stored-value></pair>
-<pair><displayed-value>Moses, Michael</displayed-value><stored-value>331714</stored-value></pair>
-<pair><displayed-value>Moulines, Eric</displayed-value><stored-value>342788</stored-value></pair>
-
-<pair><displayed-value>Muehlfeld, Katrin</displayed-value><stored-value>415922</stored-value></pair>
-<pair><displayed-value>Mueller, Holger M.</displayed-value><stored-value>163369</stored-value></pair>
-<pair><displayed-value>Mukhopadhyay, Tridas</displayed-value><stored-value>264189</stored-value></pair>
-<pair><displayed-value>Mulani, Sunil</displayed-value><stored-value>429440</stored-value></pair>
-<pair><displayed-value>Muller, Holger M.</displayed-value><stored-value>1148142</stored-value></pair>
-<pair><displayed-value>Musto, David K.</displayed-value><stored-value>205891</stored-value></pair>
-
-<pair><displayed-value>Myers, Stewart C.</displayed-value><stored-value>17423</stored-value></pair>
-<pair><displayed-value>M¬∏ller, Holger M.</displayed-value><stored-value>1148427</stored-value></pair>
-<pair><displayed-value>N. Harris, Mark</displayed-value><stored-value>1132670</stored-value></pair>
-<pair><displayed-value>NEELANKAVIL, JAMES P.</displayed-value><stored-value>1147616</stored-value></pair>
-<pair><displayed-value>Nagar, Venky</displayed-value><stored-value>150861</stored-value></pair>
-<pair><displayed-value>Nagarajan, S.</displayed-value><stored-value>1149006</stored-value></pair>
-
-<pair><displayed-value>Nagel, Stefan</displayed-value><stored-value>276811</stored-value></pair>
-<pair><displayed-value>Naik, Narayan Y.</displayed-value><stored-value>41033</stored-value></pair>
-<pair><displayed-value>Nair, Vinay B.</displayed-value><stored-value>88994</stored-value></pair>
-<pair><displayed-value>Nalebuff, Barry</displayed-value><stored-value>36229</stored-value></pair>
-<pair><displayed-value>Nam, Kwanghee</displayed-value><stored-value>137418</stored-value></pair>
-<pair><displayed-value>Nam, Seunghan</displayed-value><stored-value>391569</stored-value></pair>
-
-<pair><displayed-value>Nanda, Harsh</displayed-value><stored-value>1133323</stored-value></pair>
-<pair><displayed-value>Nanda, Vikram K.</displayed-value><stored-value>17302</stored-value></pair>
-<pair><displayed-value>Nandy, Debarshi</displayed-value><stored-value>205512</stored-value></pair>
-<pair><displayed-value>Napp, Clotilde</displayed-value><stored-value>648933</stored-value></pair>
-<pair><displayed-value>Narayanan, Paul</displayed-value><stored-value>686554</stored-value></pair>
-<pair><displayed-value>Narayanan, Ranga</displayed-value><stored-value>45905</stored-value></pair>
-
-<pair><displayed-value>Nashikkar, Amrut J.</displayed-value><stored-value>596984</stored-value></pair>
-<pair><displayed-value>Natalucci, Fabio Massimo</displayed-value><stored-value>91443</stored-value></pair>
-<pair><displayed-value>Neal, Terry L.</displayed-value><stored-value>51250</stored-value></pair>
-<pair><displayed-value>Nelson, Lee</displayed-value><stored-value>1151915</stored-value></pair>
-<pair><displayed-value>Nelson, Leif D.</displayed-value><stored-value>713396</stored-value></pair>
-<pair><displayed-value>Nelson, Philip B</displayed-value><stored-value>390739</stored-value></pair>
-
-<pair><displayed-value>Neslin, Scott</displayed-value><stored-value>266318</stored-value></pair>
-<pair><displayed-value>Neuman, Irina</displayed-value><stored-value>1142946</stored-value></pair>
-<pair><displayed-value>Neumeyer, Pablo A.</displayed-value><stored-value>371489</stored-value></pair>
-<pair><displayed-value>Nielsen, Kasper Meisner</displayed-value><stored-value>333077</stored-value></pair>
-<pair><displayed-value>Nieuwerburgh, Van</displayed-value><stored-value>1146521</stored-value></pair>
-<pair><displayed-value>Nijman, Theo E.</displayed-value><stored-value>204454</stored-value></pair>
-
-<pair><displayed-value>Niskanen, William A.</displayed-value><stored-value>59468</stored-value></pair>
-<pair><displayed-value>Nissim, Doron</displayed-value><stored-value>161870</stored-value></pair>
-<pair><displayed-value>Nordhaus, William D.</displayed-value><stored-value>96028</stored-value></pair>
-<pair><displayed-value>Ntoulas, Alexandros</displayed-value><stored-value>1131960</stored-value></pair>
-<pair><displayed-value>O'Callaghan, Ramon</displayed-value><stored-value>1135965</stored-value></pair>
-<pair><displayed-value>O'Hara, Maureen</displayed-value><stored-value>16137</stored-value></pair>
-
-<pair><displayed-value>Oates, Wallace</displayed-value><stored-value>249178</stored-value></pair>
-<pair><displayed-value>Oestreicher-Singer, Gal</displayed-value><stored-value>565076</stored-value></pair>
-<pair><displayed-value>Ofek, Eli</displayed-value><stored-value>15129</stored-value></pair>
-<pair><displayed-value>Ofeka, Eli</displayed-value><stored-value>1148144</stored-value></pair>
-<pair><displayed-value>Ogden, Joseph P.</displayed-value><stored-value>77772</stored-value></pair>
-<pair><displayed-value>Ogneva, Maria</displayed-value><stored-value>370476</stored-value></pair>
-
-<pair><displayed-value>Oh, Wonseok</displayed-value><stored-value>415754</stored-value></pair>
-<pair><displayed-value>Ohanian, Lee E.</displayed-value><stored-value>15006</stored-value></pair>
-<pair><displayed-value>Ohlson, James A.</displayed-value><stored-value>825636</stored-value></pair>
-<pair><displayed-value>Ohno, Saburo</displayed-value><stored-value>680542</stored-value></pair>
-<pair><displayed-value>Okunev, John</displayed-value><stored-value>27496</stored-value></pair>
-<pair><displayed-value>Olson, Margrethe</displayed-value><stored-value>1141330</stored-value></pair>
-
-<pair><displayed-value>Onorato, Mario</displayed-value><stored-value>341096</stored-value></pair>
-<pair><displayed-value>Oppenheimer, Daniel M.</displayed-value><stored-value>845610</stored-value></pair>
-<pair><displayed-value>Orazem, Peter Francis</displayed-value><stored-value>36060</stored-value></pair>
-<pair><displayed-value>Ordover, Janusz A.</displayed-value><stored-value>78992</stored-value></pair>
-<pair><displayed-value>Orlikowski, Wanda J.</displayed-value><stored-value>25830</stored-value></pair>
-<pair><displayed-value>Oswald, Dennis R.</displayed-value><stored-value>328933</stored-value></pair>
-
-<pair><displayed-value>Otsuki, Toshiyuki</displayed-value><stored-value>67456</stored-value></pair>
-<pair><displayed-value>Ou, Ernest Y.</displayed-value><stored-value>332311</stored-value></pair>
-<pair><displayed-value>Ou-Yang, Hui</displayed-value><stored-value>295767</stored-value></pair>
-<pair><displayed-value>Owen, Bruce M.</displayed-value><stored-value>80492</stored-value></pair>
-<pair><displayed-value>Owen, Guillermo</displayed-value><stored-value>47243</stored-value></pair>
-<pair><displayed-value>Owen, Joel</displayed-value><stored-value>104168</stored-value></pair>
-
-<pair><displayed-value>Owens, Karl R.</displayed-value><stored-value>1143345</stored-value></pair>
-<pair><displayed-value>Ozdaglar, Asuman E.</displayed-value><stored-value>452354</stored-value></pair>
-<pair><displayed-value>Ozelge, Sadi</displayed-value><stored-value>655515</stored-value></pair>
-<pair><displayed-value>Pacheco-de-Almeida, Gon√Åalo</displayed-value><stored-value>328265</stored-value></pair>
-<pair><displayed-value>Padberg, M.</displayed-value><stored-value>1144326</stored-value></pair>
-<pair><displayed-value>Padmanabhan, Balaji</displayed-value><stored-value>666707</stored-value></pair>
-
-<pair><displayed-value>Padmanabhan, Paddy V.</displayed-value><stored-value>328096</stored-value></pair>
-<pair><displayed-value>Padmanabhan, Prasad</displayed-value><stored-value>301018</stored-value></pair>
-<pair><displayed-value>Padrnanabhan, Balaji</displayed-value><stored-value>1137349</stored-value></pair>
-<pair><displayed-value>Paik, Tae-Young</displayed-value><stored-value>62892</stored-value></pair>
-<pair><displayed-value>Palia, Darius</displayed-value><stored-value>143463</stored-value></pair>
-<pair><displayed-value>Palley, Michael</displayed-value><stored-value>447168</stored-value></pair>
-
-<pair><displayed-value>Pan, Xin</displayed-value><stored-value>1060697</stored-value></pair>
-<pair><displayed-value>Pantzalis, Christos</displayed-value><stored-value>223540</stored-value></pair>
-<pair><displayed-value>Panunzi, Fausto</displayed-value><stored-value>368608</stored-value></pair>
-<pair><displayed-value>Pardo, ‚àö?ngel</displayed-value><stored-value>1148431</stored-value></pair>
-<pair><displayed-value>Park, James M.</displayed-value><stored-value>67971</stored-value></pair>
-<pair><displayed-value>Park, Sang Yong</displayed-value><stored-value>597160</stored-value></pair>
-
-<pair><displayed-value>Park, Young-Hoon</displayed-value><stored-value>117020</stored-value></pair>
-<pair><displayed-value>Paroush, Jacob</displayed-value><stored-value>32045</stored-value></pair>
-<pair><displayed-value>Pascual, Roberto</displayed-value><stored-value>1148429</stored-value></pair>
-<pair><displayed-value>Paskov, Spassimir H.</displayed-value><stored-value>16069</stored-value></pair>
-<pair><displayed-value>Pasquariello, Paolo</displayed-value><stored-value>250093</stored-value></pair>
-<pair><displayed-value>Passell, Peter</displayed-value><stored-value>200190</stored-value></pair>
-
-<pair><displayed-value>Pasternack, Brent</displayed-value><stored-value>707612</stored-value></pair>
-<pair><displayed-value>Patton, Andrew J.</displayed-value><stored-value>205520</stored-value></pair>
-<pair><displayed-value>Paul, Sharoda</displayed-value><stored-value>554695</stored-value></pair>
-<pair><displayed-value>Pavlova, Anna</displayed-value><stored-value>242365</stored-value></pair>
-<pair><displayed-value>Pazgal, Amit I.</displayed-value><stored-value>73057</stored-value></pair>
-<pair><displayed-value>Pedersen, Lasse Heje</displayed-value><stored-value>277060</stored-value></pair>
-
-<pair><displayed-value>Pedersenz, Lasse Heje</displayed-value><stored-value>1153789</stored-value></pair>
-<pair><displayed-value>Peltzman, Sam</displayed-value><stored-value>93807</stored-value></pair>
-<pair><displayed-value>Peracchi, Franco</displayed-value><stored-value>236452</stored-value></pair>
-<pair><displayed-value>Pereira, Pedro</displayed-value><stored-value>440910</stored-value></pair>
-<pair><displayed-value>Pereira, Pedro</displayed-value><stored-value>450770</stored-value></pair>
-<pair><displayed-value>Perez Saiz, Hector</displayed-value><stored-value>423622</stored-value></pair>
-
-<pair><displayed-value>Perez-Gonzalez, Francisco</displayed-value><stored-value>332689</stored-value></pair>
-<pair><displayed-value>Peristiani, Stavros</displayed-value><stored-value>45041</stored-value></pair>
-<pair><displayed-value>Perlich, Claudia</displayed-value><stored-value>372822</stored-value></pair>
-<pair><displayed-value>Pern√åas, Jos√à C.</displayed-value><stored-value>390222</stored-value></pair>
-<pair><displayed-value>Perri, Fabrizio</displayed-value><stored-value>242468</stored-value></pair>
-<pair><displayed-value>Peters, Edward</displayed-value><stored-value>1135984</stored-value></pair>
-
-<pair><displayed-value>Peters, James</displayed-value><stored-value>1143035</stored-value></pair>
-<pair><displayed-value>Peterson, Sandra</displayed-value><stored-value>136693</stored-value></pair>
-<pair><displayed-value>Petroni, Kathy Ruby</displayed-value><stored-value>17538</stored-value></pair>
-<pair><displayed-value>Petrovits, Christine</displayed-value><stored-value>571844</stored-value></pair>
-<pair><displayed-value>Phaneuf, Louis</displayed-value><stored-value>63610</stored-value></pair>
-<pair><displayed-value>Philip G., Berger</displayed-value><stored-value>1151304</stored-value></pair>
-
-<pair><displayed-value>Philippon, Thomas</displayed-value><stored-value>266888</stored-value></pair>
-<pair><displayed-value>Phillips, Joan M.</displayed-value><stored-value>713469</stored-value></pair>
-<pair><displayed-value>Phillips, Peter C.B.</displayed-value><stored-value>157372</stored-value></pair>
-<pair><displayed-value>Pindyck, Robert S.</displayed-value><stored-value>25841</stored-value></pair>
-<pair><displayed-value>Pinedo, Michael</displayed-value><stored-value>403012</stored-value></pair>
-<pair><displayed-value>Pinkus, Allan</displayed-value><stored-value>1141335</stored-value></pair>
-
-<pair><displayed-value>Pirrong, Craig</displayed-value><stored-value>134468</stored-value></pair>
-<pair><displayed-value>Piskorski, Tomasz</displayed-value><stored-value>780120</stored-value></pair>
-<pair><displayed-value>Pita Barros, Pedro Luis</displayed-value><stored-value>55671</stored-value></pair>
-<pair><displayed-value>Plambeck, Erica L.</displayed-value><stored-value>347793</stored-value></pair>
-<pair><displayed-value>Plerou, Vasiliki</displayed-value><stored-value>347407</stored-value></pair>
-<pair><displayed-value>Plimpton, Rodney B.</displayed-value><stored-value>1143342</stored-value></pair>
-
-<pair><displayed-value>Pojarliev, Momtchil T.</displayed-value><stored-value>272750</stored-value></pair>
-<pair><displayed-value>Polak, Ben</displayed-value><stored-value>1132675</stored-value></pair>
-<pair><displayed-value>Polak, Benjamin</displayed-value><stored-value>57809</stored-value></pair>
-<pair><displayed-value>Poltrack, David F.</displayed-value><stored-value>713360</stored-value></pair>
-<pair><displayed-value>Pope, Peter F.</displayed-value><stored-value>53330</stored-value></pair>
-<pair><displayed-value>Popkowski Leszczyc, Peter T. L.</displayed-value><stored-value>441780</stored-value></pair>
-
-<pair><displayed-value>Pople, Harry E.</displayed-value><stored-value>1142962</stored-value></pair>
-<pair><displayed-value>Portney, Paul R.</displayed-value><stored-value>96030</stored-value></pair>
-<pair><displayed-value>Poteshman, Allen M.</displayed-value><stored-value>238388</stored-value></pair>
-<pair><displayed-value>Pot√è, Valerio</displayed-value><stored-value>345615</stored-value></pair>
-<pair><displayed-value>Prabhala, N. R.</displayed-value><stored-value>1153782</stored-value></pair>
-<pair><displayed-value>Prabhu, Ajit M.</displayed-value><stored-value>1135947</stored-value></pair>
-
-<pair><displayed-value>Presentation, Sales</displayed-value><stored-value>808690</stored-value></pair>
-<pair><displayed-value>Prieger, James E.</displayed-value><stored-value>297790</stored-value></pair>
-<pair><displayed-value>Provost, Foster</displayed-value><stored-value>691208</stored-value></pair>
-<pair><displayed-value>Pukthuanthong, Kuntara</displayed-value><stored-value>330093</stored-value></pair>
-<pair><displayed-value>Pukthuanthong-Le, Kuntara</displayed-value><stored-value>1147624</stored-value></pair>
-<pair><displayed-value>Purao, Sandeep</displayed-value><stored-value>550596</stored-value></pair>
-
-<pair><displayed-value>Puri, Manju</displayed-value><stored-value>17585</stored-value></pair>
-<pair><displayed-value>Putsis, William P.</displayed-value><stored-value>194450</stored-value></pair>
-<pair><displayed-value>Pyun, Jisurk</displayed-value><stored-value>1142956</stored-value></pair>
-<pair><displayed-value>Qian, Yiming</displayed-value><stored-value>337776</stored-value></pair>
-<pair><displayed-value>Quadrini, Vincenzo</displayed-value><stored-value>128009</stored-value></pair>
-<pair><displayed-value>Quayle, Casey</displayed-value><stored-value>1143309</stored-value></pair>
-
-<pair><displayed-value>Quintos, Carmela</displayed-value><stored-value>41760</stored-value></pair>
-<pair><displayed-value>Quiohilag, Ainsley</displayed-value><stored-value>1133330</stored-value></pair>
-<pair><displayed-value>Radhakrishnan, R A</displayed-value><stored-value>1151907</stored-value></pair>
-<pair><displayed-value>Radhakrishnan, Suresh</displayed-value><stored-value>20904</stored-value></pair>
-<pair><displayed-value>Radner, Roy</displayed-value><stored-value>20784</stored-value></pair>
-<pair><displayed-value>Raghubir, Priya</displayed-value><stored-value>351205</stored-value></pair>
-
-<pair><displayed-value>Raghunathan, Rajagopal</displayed-value><stored-value>493117</stored-value></pair>
-<pair><displayed-value>Rai, Atul</displayed-value><stored-value>242331</stored-value></pair>
-<pair><displayed-value>Rajan, Raghuram G.</displayed-value><stored-value>2096</stored-value></pair>
-<pair><displayed-value>Rajan, Uday</displayed-value><stored-value>140429</stored-value></pair>
-<pair><displayed-value>Ramachandran, Vandana</displayed-value><stored-value>396373</stored-value></pair>
-<pair><displayed-value>Ramadorai, Tarun</displayed-value><stored-value>267374</stored-value></pair>
-
-<pair><displayed-value>Raman, Ananth</displayed-value><stored-value>59241</stored-value></pair>
-<pair><displayed-value>Ramanathan, Suresh</displayed-value><stored-value>505834</stored-value></pair>
-<pair><displayed-value>Rampini, Adriano A.</displayed-value><stored-value>253584</stored-value></pair>
-<pair><displayed-value>Ramsey, James B.</displayed-value><stored-value>17579</stored-value></pair>
-<pair><displayed-value>Ranciere, Romain</displayed-value><stored-value>328239</stored-value></pair>
-<pair><displayed-value>Ranganathan, Nicky</displayed-value><stored-value>1142947</stored-value></pair>
-
-<pair><displayed-value>Ranganathan, P.</displayed-value><stored-value>1142961</stored-value></pair>
-<pair><displayed-value>Ranganathan, Padmanabhan</displayed-value><stored-value>1143307</stored-value></pair>
-<pair><displayed-value>Rangel, J. Gonzalo</displayed-value><stored-value>1151299</stored-value></pair>
-<pair><displayed-value>Rangel, Jose Gonzalo</displayed-value><stored-value>697767</stored-value></pair>
-<pair><displayed-value>Rangel, Jose Gonzalo</displayed-value><stored-value>375273</stored-value></pair>
-<pair><displayed-value>Rao, Ahobala</displayed-value><stored-value>1142964</stored-value></pair>
-
-<pair><displayed-value>Rattanaruengyot, Thongchai</displayed-value><stored-value>1334985</stored-value></pair>
-<pair><displayed-value>Ravid, Abraham S</displayed-value><stored-value>1150544</stored-value></pair>
-<pair><displayed-value>Ravid, Abraham S.</displayed-value><stored-value>1150543</stored-value></pair>
-<pair><displayed-value>Ravid, S. Abraham</displayed-value><stored-value>1150545</stored-value></pair>
-<pair><displayed-value>Ravina, Enrichetta</displayed-value><stored-value>597462</stored-value></pair>
-<pair><displayed-value>Raviv, Alon</displayed-value><stored-value>342912</stored-value></pair>
-
-<pair><displayed-value>Rawley, Evan</displayed-value><stored-value>862962</stored-value></pair>
-<pair><displayed-value>Ray, Bonnie K.</displayed-value><stored-value>529197</stored-value></pair>
-<pair><displayed-value>Razin, Ronny</displayed-value><stored-value>105266</stored-value></pair>
-<pair><displayed-value>Refalo, James F.</displayed-value><stored-value>149073</stored-value></pair>
-<pair><displayed-value>Register, Charles A.</displayed-value><stored-value>124772</stored-value></pair>
-<pair><displayed-value>Reisz, Alexander</displayed-value><stored-value>428245</stored-value></pair>
-
-<pair><displayed-value>Reitman, Walter</displayed-value><stored-value>1143457</stored-value></pair>
-<pair><displayed-value>Reitman Olson, Judith</displayed-value><stored-value>1143304</stored-value></pair>
-<pair><displayed-value>Remmers, Barbara</displayed-value><stored-value>68508</stored-value></pair>
-<pair><displayed-value>Ren√ö, Roberto</displayed-value><stored-value>327190</stored-value></pair>
-<pair><displayed-value>Research Paper Series, NYU Law</displayed-value><stored-value>419245</stored-value></pair>
-<pair><displayed-value>Research Paper Series, Ross School of Business</displayed-value><stored-value>561150</stored-value></pair>
-
-<pair><displayed-value>Research Submitter, Harvard Institute of Economic</displayed-value><stored-value>1289180</stored-value></pair>
-<pair><displayed-value>Reshef, Ariell</displayed-value><stored-value>376586</stored-value></pair>
-<pair><displayed-value>Resti, Andrea</displayed-value><stored-value>223524</stored-value></pair>
-<pair><displayed-value>Rezende, Leonardo</displayed-value><stored-value>699878</stored-value></pair>
-<pair><displayed-value>Rhine, Sherrie L.W.</displayed-value><stored-value>343137</stored-value></pair>
-<pair><displayed-value>Ribeiro, Ricardo</displayed-value><stored-value>875172</stored-value></pair>
-
-<pair><displayed-value>Ribeiro, Tiago</displayed-value><stored-value>90749</stored-value></pair>
-<pair><displayed-value>Richardson, Matthew P.</displayed-value><stored-value>42753</stored-value></pair>
-<pair><displayed-value>Richardson, Thomas J.</displayed-value><stored-value>352042</stored-value></pair>
-<pair><displayed-value>Ricks, William E.</displayed-value><stored-value>183332</stored-value></pair>
-<pair><displayed-value>Rijken, Herbert A.</displayed-value><stored-value>687152</stored-value></pair>
-<pair><displayed-value>Ripston, Beth A.</displayed-value><stored-value>207829</stored-value></pair>
-
-<pair><displayed-value>Rivlin, Alice</displayed-value><stored-value>382409</stored-value></pair>
-<pair><displayed-value>Rocheteau, Guillaume</displayed-value><stored-value>302506</stored-value></pair>
-<pair><displayed-value>Rock, Edward B.</displayed-value><stored-value>44766</stored-value></pair>
-<pair><displayed-value>Rockoff, Maxine L.</displayed-value><stored-value>1142070</stored-value></pair>
-<pair><displayed-value>Rodriguez, Juan Carlos</displayed-value><stored-value>352545</stored-value></pair>
-<pair><displayed-value>Rollier, Bruce</displayed-value><stored-value>1141332</stored-value></pair>
-
-<pair><displayed-value>Ronen, Boaz</displayed-value><stored-value>350484</stored-value></pair>
-<pair><displayed-value>Roomans, Mark</displayed-value><stored-value>183608</stored-value></pair>
-<pair><displayed-value>Rosen, Harvey S.</displayed-value><stored-value>92890</stored-value></pair>
-<pair><displayed-value>Rosenberg, Joshua V.</displayed-value><stored-value>44290</stored-value></pair>
-<pair><displayed-value>Rosenfeld, James</displayed-value><stored-value>44449</stored-value></pair>
-<pair><displayed-value>Ross, Stephen A.</displayed-value><stored-value>26373</stored-value></pair>
-
-<pair><displayed-value>Ross, Thomas W.</displayed-value><stored-value>938481</stored-value></pair>
-<pair><displayed-value>Rosset, Saharon</displayed-value><stored-value>1131948</stored-value></pair>
-<pair><displayed-value>Rosston, Gregory L.</displayed-value><stored-value>332917</stored-value></pair>
-<pair><displayed-value>Rotem, Doron</displayed-value><stored-value>1133795</stored-value></pair>
-<pair><displayed-value>Rothkopf, Michael H.</displayed-value><stored-value>17905</stored-value></pair>
-<pair><displayed-value>Rousseau, Peter L.</displayed-value><stored-value>66255</stored-value></pair>
-
-<pair><displayed-value>Roy, Ritendra</displayed-value><stored-value>1133335</stored-value></pair>
-<pair><displayed-value>Ruback, Richard S.</displayed-value><stored-value>58677</stored-value></pair>
-<pair><displayed-value>Russell, Jeffrey R.</displayed-value><stored-value>16081</stored-value></pair>
-<pair><displayed-value>Russell, Milton</displayed-value><stored-value>711565</stored-value></pair>
-<pair><displayed-value>Ruta, Sebastian</displayed-value><stored-value>1133338</stored-value></pair>
-<pair><displayed-value>Ruthenberg, David</displayed-value><stored-value>451347</stored-value></pair>
-
-<pair><displayed-value>Ryan, Joe</displayed-value><stored-value>405104</stored-value></pair>
-<pair><displayed-value>Ryan, Stephen</displayed-value><stored-value>404883</stored-value></pair>
-<pair><displayed-value>Ryan, Stephen G.</displayed-value><stored-value>20955</stored-value></pair>
-<pair><displayed-value>Rysman, Marc</displayed-value><stored-value>274698</stored-value></pair>
-<pair><displayed-value>SMITH, Ronn J.</displayed-value><stored-value>882537</stored-value></pair>
-<pair><displayed-value>SPROTT, David</displayed-value><stored-value>882539</stored-value></pair>
-
-<pair><displayed-value>Saar, Gideon</displayed-value><stored-value>245988</stored-value></pair>
-<pair><displayed-value>Saar-Tsechansky, Maytal</displayed-value><stored-value>691185</stored-value></pair>
-<pair><displayed-value>Saar-Tsechansky, Maytal</displayed-value><stored-value>1133979</stored-value></pair>
-<pair><displayed-value>Sabato, Gabriele</displayed-value><stored-value>451378</stored-value></pair>
-<pair><displayed-value>Sade, Orly</displayed-value><stored-value>291969</stored-value></pair>
-<pair><displayed-value>Saggi, Kamal</displayed-value><stored-value>119671</stored-value></pair>
-
-<pair><displayed-value>Sajeesh, S.</displayed-value><stored-value>996882</stored-value></pair>
-<pair><displayed-value>Salant, David J.</displayed-value><stored-value>537210</stored-value></pair>
-<pair><displayed-value>Salinger, Michael A.</displayed-value><stored-value>701757</stored-value></pair>
-<pair><displayed-value>Sangvinatsos, Antonios A.</displayed-value><stored-value>352547</stored-value></pair>
-<pair><displayed-value>Sankaranarayanan, Ramesh</displayed-value><stored-value>363750</stored-value></pair>
-<pair><displayed-value>Sankaranarayanan, Ramesh</displayed-value><stored-value>499322</stored-value></pair>
-
-<pair><displayed-value>Sannikov, Yuliy</displayed-value><stored-value>382854</stored-value></pair>
-<pair><displayed-value>Santos, Jo‚Äûo A.C.</displayed-value><stored-value>103125</stored-value></pair>
-<pair><displayed-value>Sapienza, Paola</displayed-value><stored-value>73429</stored-value></pair>
-<pair><displayed-value>Sarath, Bharat</displayed-value><stored-value>50181</stored-value></pair>
-<pair><displayed-value>Sarkar, Debojyoti</displayed-value><stored-value>80669</stored-value></pair>
-<pair><displayed-value>Sasso, William C.</displayed-value><stored-value>1142957</stored-value></pair>
-
-<pair><displayed-value>Satchell, Stephen E.</displayed-value><stored-value>44149</stored-value></pair>
-<pair><displayed-value>Saunders, Anthony</displayed-value><stored-value>17647</stored-value></pair>
-<pair><displayed-value>Saundersc, Anthony</displayed-value><stored-value>1148141</stored-value></pair>
-<pair><displayed-value>Savage, Scott</displayed-value><stored-value>232519</stored-value></pair>
-<pair><displayed-value>Savitsky, Kenneth</displayed-value><stored-value>713371</stored-value></pair>
-<pair><displayed-value>Saxena, Shivanker</displayed-value><stored-value>1133326</stored-value></pair>
-
-<pair><displayed-value>Sbuelz, Alessandro</displayed-value><stored-value>103773</stored-value></pair>
-<pair><displayed-value>Scalise, Joseph M.</displayed-value><stored-value>43800</stored-value></pair>
-<pair><displayed-value>Schanzenbach, Max Matthew</displayed-value><stored-value>346044</stored-value></pair>
-<pair><displayed-value>Scheinkman, Jose A.</displayed-value><stored-value>173218</stored-value></pair>
-<pair><displayed-value>Schilling, Melissa A.</displayed-value><stored-value>341752</stored-value></pair>
-<pair><displayed-value>Schmalensee, Richard</displayed-value><stored-value>21576</stored-value></pair>
-
-<pair><displayed-value>Schmid, Markus Max</displayed-value><stored-value>362677</stored-value></pair>
-<pair><displayed-value>Schmidt, Joachim W.</displayed-value><stored-value>1143311</stored-value></pair>
-<pair><displayed-value>Schmit, Joey J</displayed-value><stored-value>688478</stored-value></pair>
-<pair><displayed-value>Schocken, Shimon</displayed-value><stored-value>1135973</stored-value></pair>
-<pair><displayed-value>Schocken, Shirnon</displayed-value><stored-value>1142075</stored-value></pair>
-<pair><displayed-value>Scholnick, Barry</displayed-value><stored-value>342904</stored-value></pair>
-
-<pair><displayed-value>School of Business Research Paper Series, Robert H. Smith</displayed-value><stored-value>603680</stored-value></pair>
-<pair><displayed-value>Schotmanz, Peter</displayed-value><stored-value>1151302</stored-value></pair>
-<pair><displayed-value>Schreiber, Ben Z.</displayed-value><stored-value>57196</stored-value></pair>
-<pair><displayed-value>Schuermann, Til</displayed-value><stored-value>145572</stored-value></pair>
-<pair><displayed-value>Schularick, Moritz</displayed-value><stored-value>585594</stored-value></pair>
-<pair><displayed-value>Schultz, Randall</displayed-value><stored-value>364229</stored-value></pair>
-
-<pair><displayed-value>Schultze, Charles L.</displayed-value><stored-value>31227</stored-value></pair>
-<pair><displayed-value>Schwartz, Robert A.</displayed-value><stored-value>50162</stored-value></pair>
-<pair><displayed-value>Schwarz, Christopher</displayed-value><stored-value>655127</stored-value></pair>
-<pair><displayed-value>Schwarz, Christopher</displayed-value><stored-value>1155876</stored-value></pair>
-<pair><displayed-value>Sealey, C.W.</displayed-value><stored-value>1149007</stored-value></pair>
-<pair><displayed-value>Seethamraju, Chandrakanth</displayed-value><stored-value>267929</stored-value></pair>
-
-<pair><displayed-value>Segal, Benjamin</displayed-value><stored-value>373065</stored-value></pair>
-<pair><displayed-value>Segal, Dan</displayed-value><stored-value>340489</stored-value></pair>
-<pair><displayed-value>Segev, Arie</displayed-value><stored-value>20473</stored-value></pair>
-<pair><displayed-value>Seidmann, Abraham</displayed-value><stored-value>17414</stored-value></pair>
-<pair><displayed-value>Seidmann, Abraham</displayed-value><stored-value>833504</stored-value></pair>
-<pair><displayed-value>Seim, Katja</displayed-value><stored-value>341307</stored-value></pair>
-
-<pair><displayed-value>Seim (Stanford), Katja</displayed-value><stored-value>1133343</stored-value></pair>
-<pair><displayed-value>Sela, Rebecca J.</displayed-value><stored-value>400970</stored-value></pair>
-<pair><displayed-value>Semmler, Willi</displayed-value><stored-value>22501</stored-value></pair>
-<pair><displayed-value>Sen, Shahana</displayed-value><stored-value>419395</stored-value></pair>
-<pair><displayed-value>Sen, Subrata K.</displayed-value><stored-value>263770</stored-value></pair>
-<pair><displayed-value>Senbet, Lemma W.</displayed-value><stored-value>16654</stored-value></pair>
-
-<pair><displayed-value>Sengupta, Anirban</displayed-value><stored-value>602010</stored-value></pair>
-<pair><displayed-value>Sengupta, Bhaskar</displayed-value><stored-value>1147607</stored-value></pair>
-<pair><displayed-value>Seppi, Duane J.</displayed-value><stored-value>15912</stored-value></pair>
-<pair><displayed-value>Serfes, Konstantinos</displayed-value><stored-value>410122</stored-value></pair>
-<pair><displayed-value>Seshadri, Sridhar</displayed-value><stored-value>357604</stored-value></pair>
-<pair><displayed-value>Sessions, David N.</displayed-value><stored-value>197348</stored-value></pair>
-
-<pair><displayed-value>Shakun, Melvin</displayed-value><stored-value>548112</stored-value></pair>
-<pair><displayed-value>Shalev, Jacob</displayed-value><stored-value>1143323</stored-value></pair>
-<pair><displayed-value>Shapira, Zur</displayed-value><stored-value>287062</stored-value></pair>
-<pair><displayed-value>Shapiro, Alex</displayed-value><stored-value>159948</stored-value></pair>
-<pair><displayed-value>Shavell, Steven</displayed-value><stored-value>17058</stored-value></pair>
-<pair><displayed-value>Shelanski, Howard A.</displayed-value><stored-value>17257</stored-value></pair>
-
-<pair><displayed-value>Shen, Michael</displayed-value><stored-value>458317</stored-value></pair>
-<pair><displayed-value>Shen, YuQing</displayed-value><stored-value>1148424</stored-value></pair>
-<pair><displayed-value>Sheng, Victor</displayed-value><stored-value>1131964</stored-value></pair>
-<pair><displayed-value>Sheopuri, Anshul</displayed-value><stored-value>1143351</stored-value></pair>
-<pair><displayed-value>Sheopuri, Dr. Anshul</displayed-value><stored-value>1147153</stored-value></pair>
-<pair><displayed-value>Shephard, Neil</displayed-value><stored-value>74737</stored-value></pair>
-
-<pair><displayed-value>Sheppard, Kevin</displayed-value><stored-value>287786</stored-value></pair>
-<pair><displayed-value>Shi, Charles</displayed-value><stored-value>49308</stored-value></pair>
-<pair><displayed-value>Shi, Shanming</displayed-value><stored-value>97515</stored-value></pair>
-<pair><displayed-value>Shi, Yunfeng</displayed-value><stored-value>498239</stored-value></pair>
-<pair><displayed-value>Shiftan, Joseph</displayed-value><stored-value>1142965</stored-value></pair>
-<pair><displayed-value>Shillinglaw, Gordon</displayed-value><stored-value>1143322</stored-value></pair>
-
-<pair><displayed-value>Shin, Hyun Song</displayed-value><stored-value>15041</stored-value></pair>
-<pair><displayed-value>Shin, Hyun Song</displayed-value><stored-value>912778</stored-value></pair>
-<pair><displayed-value>Shiraishi, Noriyoshi</displayed-value><stored-value>83708</stored-value></pair>
-<pair><displayed-value>Shivdasani, Anil</displayed-value><stored-value>17540</stored-value></pair>
-<pair><displayed-value>Shleifer, Andrei</displayed-value><stored-value>17066</stored-value></pair>
-<pair><displayed-value>Short, James E.</displayed-value><stored-value>982630</stored-value></pair>
-
-<pair><displayed-value>Shu, Jinghong</displayed-value><stored-value>1147160</stored-value></pair>
-<pair><displayed-value>Sicker, Douglas</displayed-value><stored-value>417765</stored-value></pair>
-<pair><displayed-value>Sidak, J. Gregory</displayed-value><stored-value>206474</stored-value></pair>
-<pair><displayed-value>Silberschatz, Avi</displayed-value><stored-value>1142073</stored-value></pair>
-<pair><displayed-value>Silver, Mark S.</displayed-value><stored-value>1137358</stored-value></pair>
-<pair><displayed-value>Simaan, Yusif</displayed-value><stored-value>142768</stored-value></pair>
-
-<pair><displayed-value>Simcoe, Timothy S.</displayed-value><stored-value>377924</stored-value></pair>
-<pair><displayed-value>Simon, Bobe E.</displayed-value><stored-value>119010</stored-value></pair>
-<pair><displayed-value>Simon, Gary</displayed-value><stored-value>415755</stored-value></pair>
-<pair><displayed-value>Simonoff, Jeffrey S.</displayed-value><stored-value>1133781</stored-value></pair>
-<pair><displayed-value>Singh, Nirvikar</displayed-value><stored-value>48355</stored-value></pair>
-<pair><displayed-value>Singh, Rajdeep</displayed-value><stored-value>172368</stored-value></pair>
-
-<pair><displayed-value>Singleton, Kenneth J.</displayed-value><stored-value>15716</stored-value></pair>
-<pair><displayed-value>Sinha, Nishi</displayed-value><stored-value>20922</stored-value></pair>
-<pair><displayed-value>Siniscalchi, Marciano</displayed-value><stored-value>165589</stored-value></pair>
-<pair><displayed-value>Sironi, Andrea</displayed-value><stored-value>253494</stored-value></pair>
-<pair><displayed-value>Sisli, Elif</displayed-value><stored-value>1155486</stored-value></pair>
-<pair><displayed-value>Sisli Ciamarra, Elif</displayed-value><stored-value>476798</stored-value></pair>
-
-<pair><displayed-value>Sitkoff, Robert H.</displayed-value><stored-value>230213</stored-value></pair>
-<pair><displayed-value>Sivasankaran, Taracad</displayed-value><stored-value>1143318</stored-value></pair>
-<pair><displayed-value>Skinner, Frank S.</displayed-value><stored-value>17652</stored-value></pair>
-<pair><displayed-value>Skreta, Vasiliki</displayed-value><stored-value>402892</stored-value></pair>
-<pair><displayed-value>Skrzypacz, Andrzej</displayed-value><stored-value>329310</stored-value></pair>
-<pair><displayed-value>Slade, Stephen</displayed-value><stored-value>1137363</stored-value></pair>
-
-<pair><displayed-value>Slaughter, Sandra</displayed-value><stored-value>370987</stored-value></pair>
-<pair><displayed-value>Smith, Aaron D.</displayed-value><stored-value>106050</stored-value></pair>
-<pair><displayed-value>Smith, Alastair</displayed-value><stored-value>1085021</stored-value></pair>
-<pair><displayed-value>Smith, Michael D.</displayed-value><stored-value>291479</stored-value></pair>
-<pair><displayed-value>Smith, Tom M.</displayed-value><stored-value>27446</stored-value></pair>
-<pair><displayed-value>Smith, V. Kerry</displayed-value><stored-value>31972</stored-value></pair>
-
-<pair><displayed-value>Smith, Vernon L.</displayed-value><stored-value>74192</stored-value></pair>
-<pair><displayed-value>Snodgrass, Richard T.</displayed-value><stored-value>729120</stored-value></pair>
-<pair><displayed-value>Snyder, Christopher M.</displayed-value><stored-value>782</stored-value></pair>
-<pair><displayed-value>Soares, Jorge</displayed-value><stored-value>54267</stored-value></pair>
-<pair><displayed-value>Sodini, Paolo</displayed-value><stored-value>286236</stored-value></pair>
-<pair><displayed-value>Sohn, Bumjean</displayed-value><stored-value>673054</stored-value></pair>
-
-<pair><displayed-value>Sokalska, Magdalena</displayed-value><stored-value>327383</stored-value></pair>
-<pair><displayed-value>Soler, Montserrat</displayed-value><stored-value>657431</stored-value></pair>
-<pair><displayed-value>Soliman, Mark T.</displayed-value><stored-value>276270</stored-value></pair>
-<pair><displayed-value>Solow, Robert M.</displayed-value><stored-value>21582</stored-value></pair>
-<pair><displayed-value>Song, Keke</displayed-value><stored-value>753418</stored-value></pair>
-<pair><displayed-value>Sougiannis, Theodore</displayed-value><stored-value>15044</stored-value></pair>
-
-<pair><displayed-value>Soulier, Philippe</displayed-value><stored-value>342789</stored-value></pair>
-<pair><displayed-value>Souliery, Philippe</displayed-value><stored-value>1147612</stored-value></pair>
-<pair><displayed-value>Spangenberg, Eric R.</displayed-value><stored-value>674332</stored-value></pair>
-<pair><displayed-value>Sparrow, Ilana R.</displayed-value><stored-value>1143354</stored-value></pair>
-<pair><displayed-value>Spear, Stephen E.</displayed-value><stored-value>331127</stored-value></pair>
-<pair><displayed-value>Spiegel, Matthew I.</displayed-value><stored-value>987</stored-value></pair>
-
-<pair><displayed-value>Spiegel, Yossi</displayed-value><stored-value>46040</stored-value></pair>
-<pair><displayed-value>Spiller, Pablo T.</displayed-value><stored-value>16129</stored-value></pair>
-<pair><displayed-value>Spindt, Paul A.</displayed-value><stored-value>21933</stored-value></pair>
-<pair><displayed-value>Spitler, Valerie K.</displayed-value><stored-value>1135954</stored-value></pair>
-<pair><displayed-value>Spitzer, Jonathan F.</displayed-value><stored-value>395259</stored-value></pair>
-<pair><displayed-value>Spulber, Daniel F.</displayed-value><stored-value>31293</stored-value></pair>
-
-<pair><displayed-value>Sraer, David</displayed-value><stored-value>1132953</stored-value></pair>
-<pair><displayed-value>Srikanth, Rajan</displayed-value><stored-value>1142084</stored-value></pair>
-<pair><displayed-value>Srinivasan, Anand</displayed-value><stored-value>505298</stored-value></pair>
-<pair><displayed-value>Stacchetti, Ennio S.</displayed-value><stored-value>159550</stored-value></pair>
-<pair><displayed-value>Stango, Victor</displayed-value><stored-value>243208</stored-value></pair>
-<pair><displayed-value>Stanley, H. Eugene</displayed-value><stored-value>137873</stored-value></pair>
-
-<pair><displayed-value>Stanton, Richard H.</displayed-value><stored-value>15164</stored-value></pair>
-<pair><displayed-value>Stapleton, R.C</displayed-value><stored-value>1148487</stored-value></pair>
-<pair><displayed-value>Stapleton, Richard</displayed-value><stored-value>358985</stored-value></pair>
-<pair><displayed-value>Starbuck, William H.</displayed-value><stored-value>345906</stored-value></pair>
-<pair><displayed-value>Starks, Laura T.</displayed-value><stored-value>17269</stored-value></pair>
-<pair><displayed-value>Stavins, Robert N.</displayed-value><stored-value>26285</stored-value></pair>
-
-<pair><displayed-value>Steckel, Joel</displayed-value><stored-value>1749</stored-value></pair>
-<pair><displayed-value>Steenbeek, Onno W.</displayed-value><stored-value>12019</stored-value></pair>
-<pair><displayed-value>Stein, Jeremy C.</displayed-value><stored-value>17459</stored-value></pair>
-<pair><displayed-value>Stein, Roger M.</displayed-value><stored-value>1133983</stored-value></pair>
-<pair><displayed-value>Steindel, Charles</displayed-value><stored-value>335739</stored-value></pair>
-<pair><displayed-value>Stiglitz, Joseph E.</displayed-value><stored-value>292740</stored-value></pair>
-
-<pair><displayed-value>Stohr, Edward</displayed-value><stored-value>1141313</stored-value></pair>
-<pair><displayed-value>Stohr, Edward A.</displayed-value><stored-value>1133779</stored-value></pair>
-<pair><displayed-value>Storeletten, Kjetil</displayed-value><stored-value>1132680</stored-value></pair>
-<pair><displayed-value>Storeslettenand, Kjetil</displayed-value><stored-value>1154635</stored-value></pair>
-<pair><displayed-value>Stover, Roger D.</displayed-value><stored-value>52304</stored-value></pair>
-<pair><displayed-value>Strahan, Philip E.</displayed-value><stored-value>16357</stored-value></pair>
-
-<pair><displayed-value>Streeter, Lynn A.</displayed-value><stored-value>1135977</stored-value></pair>
-<pair><displayed-value>Strelcova, Jelena</displayed-value><stored-value>1133327</stored-value></pair>
-<pair><displayed-value>Stremme, Alexander</displayed-value><stored-value>138712</stored-value></pair>
-<pair><displayed-value>Stroughair, John</displayed-value><stored-value>143390</stored-value></pair>
-<pair><displayed-value>Struis, Corine</displayed-value><stored-value>397391</stored-value></pair>
-<pair><displayed-value>Strulovici, Bruno H.</displayed-value><stored-value>405596</stored-value></pair>
-
-<pair><displayed-value>Stuart, Harborne (Gus) W.</displayed-value><stored-value>266287</stored-value></pair>
-<pair><displayed-value>Stuchfield, Nic</displayed-value><stored-value>1141337</stored-value></pair>
-<pair><displayed-value>Stulz, Rene M.</displayed-value><stored-value>17753</stored-value></pair>
-<pair><displayed-value>Su, Meng</displayed-value><stored-value>996915</stored-value></pair>
-<pair><displayed-value>Submitter, Banco de Espana Research Paper</displayed-value><stored-value>613124</stored-value></pair>
-<pair><displayed-value>Submitter, Boston U School of Managment</displayed-value><stored-value>1150988</stored-value></pair>
-
-<pair><displayed-value>Submitter, CESifo</displayed-value><stored-value>459177</stored-value></pair>
-<pair><displayed-value>Submitter, IESE</displayed-value><stored-value>361123</stored-value></pair>
-<pair><displayed-value>Submitter, INSEAD Research Paper Series</displayed-value><stored-value>865831</stored-value></pair>
-<pair><displayed-value>Submitter, Reg-Markets</displayed-value><stored-value>344990</stored-value></pair>
-<pair><displayed-value>Submitter, Rock Center</displayed-value><stored-value>1199479</stored-value></pair>
-<pair><displayed-value>Submitter, Stanford GSB</displayed-value><stored-value>363555</stored-value></pair>
-
-<pair><displayed-value>Subrahmanyam, Marti G.</displayed-value><stored-value>738</stored-value></pair>
-<pair><displayed-value>Subramanian, Krishnamurthy</displayed-value><stored-value>114749</stored-value></pair>
-<pair><displayed-value>Sudhir, K</displayed-value><stored-value>106058</stored-value></pair>
-<pair><displayed-value>Suggitt, Heather J.</displayed-value><stored-value>62509</stored-value></pair>
-<pair><displayed-value>Sun, Baohong</displayed-value><stored-value>328069</stored-value></pair>
-<pair><displayed-value>Sun, Zheng</displayed-value><stored-value>451407</stored-value></pair>
-
-<pair><displayed-value>Sundaram, Rangarajan K.</displayed-value><stored-value>58699</stored-value></pair>
-<pair><displayed-value>Sundararajan, Arun</displayed-value><stored-value>21042</stored-value></pair>
-<pair><displayed-value>Sunder, Shyam</displayed-value><stored-value>160390</stored-value></pair>
-<pair><displayed-value>Sunder, Shyam Vallabhajosyula</displayed-value><stored-value>332913</stored-value></pair>
-<pair><displayed-value>Sundgren, S.</displayed-value><stored-value>1151909</stored-value></pair>
-<pair><displayed-value>Suo, Wulin</displayed-value><stored-value>97747</stored-value></pair>
-
-<pair><displayed-value>Swait, Joffre</displayed-value><stored-value>59</stored-value></pair>
-<pair><displayed-value>Swan, Peter Lawrence</displayed-value><stored-value>136389</stored-value></pair>
-<pair><displayed-value>Swary, Itzhak</displayed-value><stored-value>1152402</stored-value></pair>
-<pair><displayed-value>Sweeney, James L.</displayed-value><stored-value>21014</stored-value></pair>
-<pair><displayed-value>Swope, Matthew</displayed-value><stored-value>1133339</stored-value></pair>
-<pair><displayed-value>Syam, Niladri B.</displayed-value><stored-value>328050</stored-value></pair>
-
-<pair><displayed-value>Syverson, Chad</displayed-value><stored-value>342888</stored-value></pair>
-<pair><displayed-value>Szabo, Gabor</displayed-value><stored-value>1149670</stored-value></pair>
-<pair><displayed-value>Szczesny, Chiara</displayed-value><stored-value>596155</stored-value></pair>
-<pair><displayed-value>S¬∏lzle, Kai</displayed-value><stored-value>327899</stored-value></pair>
-<pair><displayed-value>Taliaferro, Ryan</displayed-value><stored-value>400915</stored-value></pair>
-<pair><displayed-value>Tan, Sinan</displayed-value><stored-value>337586</stored-value></pair>
-
-<pair><displayed-value>Tan, Sinan</displayed-value><stored-value>780139</stored-value></pair>
-<pair><displayed-value>Tang, Yi</displayed-value><stored-value>481381</stored-value></pair>
-<pair><displayed-value>Tanniru, Mohan R.</displayed-value><stored-value>1143356</stored-value></pair>
-<pair><displayed-value>Tashjian, Richard</displayed-value><stored-value>1147170</stored-value></pair>
-<pair><displayed-value>Tasley, Roberta</displayed-value><stored-value>1143324</stored-value></pair>
-<pair><displayed-value>Tawfik Jelassi, Mohamed</displayed-value><stored-value>1143316</stored-value></pair>
-
-<pair><displayed-value>Tay, Anothony S.</displayed-value><stored-value>1152396</stored-value></pair>
-<pair><displayed-value>Tay, Anthony S.</displayed-value><stored-value>145355</stored-value></pair>
-<pair><displayed-value>Taylor, Scott R.</displayed-value><stored-value>1132236</stored-value></pair>
-<pair><displayed-value>Tchistyi, Alexei</displayed-value><stored-value>468734</stored-value></pair>
-<pair><displayed-value>Teall, John L.</displayed-value><stored-value>88620</stored-value></pair>
-<pair><displayed-value>Teece, David J.</displayed-value><stored-value>209629</stored-value></pair>
-
-<pair><displayed-value>Tehranian, Hassan</displayed-value><stored-value>15851</stored-value></pair>
-<pair><displayed-value>Telang, Rahul</displayed-value><stored-value>264190</stored-value></pair>
-<pair><displayed-value>Tellis, Gerard J.</displayed-value><stored-value>117251</stored-value></pair>
-<pair><displayed-value>Telmer, Chris</displayed-value><stored-value>1151298</stored-value></pair>
-<pair><displayed-value>Telmer, Christopher I.</displayed-value><stored-value>81288</stored-value></pair>
-<pair><displayed-value>Teoman, Tuygan</displayed-value><stored-value>1133336</stored-value></pair>
-
-<pair><displayed-value>Tepla, Lucie</displayed-value><stored-value>303081</stored-value></pair>
-<pair><displayed-value>Theisen, Mary Beth</displayed-value><stored-value>1142063</stored-value></pair>
-<pair><displayed-value>Thesmar, David</displayed-value><stored-value>328030</stored-value></pair>
-<pair><displayed-value>Thomas, Jacquelyn</displayed-value><stored-value>106065</stored-value></pair>
-<pair><displayed-value>Thomas, Lee R.</displayed-value><stored-value>236721</stored-value></pair>
-<pair><displayed-value>Thomas, Manoj</displayed-value><stored-value>663904</stored-value></pair>
-
-<pair><displayed-value>Thomas III, Lee R.</displayed-value><stored-value>1147625</stored-value></pair>
-<pair><displayed-value>Thuering, Manfred</displayed-value><stored-value>1135972</stored-value></pair>
-<pair><displayed-value>Timmer, Jens</displayed-value><stored-value>1133787</stored-value></pair>
-<pair><displayed-value>Tinkelman, Daniel</displayed-value><stored-value>230947</stored-value></pair>
-<pair><displayed-value>Titman, Sheridan</displayed-value><stored-value>15836</stored-value></pair>
-<pair><displayed-value>Toussaint-Comeau, Maude</displayed-value><stored-value>343136</stored-value></pair>
-
-<pair><displayed-value>Touzi, Nizar</displayed-value><stored-value>101146</stored-value></pair>
-<pair><displayed-value>Touzi, Nizar</displayed-value><stored-value>140257</stored-value></pair>
-<pair><displayed-value>Trietsch, Dan</displayed-value><stored-value>1142960</stored-value></pair>
-<pair><displayed-value>Trigeorgis, Lenos</displayed-value><stored-value>33458</stored-value></pair>
-<pair><displayed-value>Trigueros, Joaguin R.</displayed-value><stored-value>1152398</stored-value></pair>
-<pair><displayed-value>Trimbath, Susanne</displayed-value><stored-value>272819</stored-value></pair>
-
-<pair><displayed-value>Trombley, Mark A.</displayed-value><stored-value>16046</stored-value></pair>
-<pair><displayed-value>Truman, Gregory E.</displayed-value><stored-value>1135961</stored-value></pair>
-<pair><displayed-value>Trzcinka, Charles</displayed-value><stored-value>16076</stored-value></pair>
-<pair><displayed-value>Tsai, Janice</displayed-value><stored-value>703063</stored-value></pair>
-<pair><displayed-value>Tsai, Chih-Ling</displayed-value><stored-value>1283</stored-value></pair>
-<pair><displayed-value>Tsechansky, Maytal</displayed-value><stored-value>1141323</stored-value></pair>
-
-<pair><displayed-value>Tsui, Judy S.L.</displayed-value><stored-value>62753</stored-value></pair>
-<pair><displayed-value>Tucker, Catherine</displayed-value><stored-value>512675</stored-value></pair>
-<pair><displayed-value>Tucker, Jenny</displayed-value><stored-value>393576</stored-value></pair>
-<pair><displayed-value>Tucker, X. Jenny</displayed-value><stored-value>1131966</stored-value></pair>
-<pair><displayed-value>Tumarkin, Robert</displayed-value><stored-value>278008</stored-value></pair>
-<pair><displayed-value>Tunca, Tunay Ihsan</displayed-value><stored-value>253558</stored-value></pair>
-
-<pair><displayed-value>Turner, Jon</displayed-value><stored-value>475355</stored-value></pair>
-<pair><displayed-value>Tuzhilin, Alexander</displayed-value><stored-value>1131950</stored-value></pair>
-<pair><displayed-value>Tyson, Laura D'Andrea</displayed-value><stored-value>21995</stored-value></pair>
-<pair><displayed-value>T√Çg, Joacim</displayed-value><stored-value>397712</stored-value></pair>
-<pair><displayed-value>Udell, Gregory F.</displayed-value><stored-value>43802</stored-value></pair>
-<pair><displayed-value>Uhlig, Harald</displayed-value><stored-value>56541</stored-value></pair>
-
-<pair><displayed-value>Ulkumen, Gulden</displayed-value><stored-value>712128</stored-value></pair>
-<pair><displayed-value>Umapathy, Karthikeyan</displayed-value><stored-value>554694</stored-value></pair>
-<pair><displayed-value>Umyarov, Akhmed</displayed-value><stored-value>1131963</stored-value></pair>
-<pair><displayed-value>Uno, Jun</displayed-value><stored-value>131769</stored-value></pair>
-<pair><displayed-value>Uretsky, Myron</displayed-value><stored-value>475365</stored-value></pair>
-<pair><displayed-value>Vaaste, Emmanuelle</displayed-value><stored-value>1131953</stored-value></pair>
-
-<pair><displayed-value>Valkonen, Sami</displayed-value><stored-value>608393</stored-value></pair>
-<pair><displayed-value>Van Alstyne, Marshall W.</displayed-value><stored-value>253298</stored-value></pair>
-<pair><displayed-value>Van Cayseele, Patrick J.G.</displayed-value><stored-value>169428</stored-value></pair>
-<pair><displayed-value>Van Nieuwerburgh, Stijn</displayed-value><stored-value>347304</stored-value></pair>
-<pair><displayed-value>Van Zandt, Timothy</displayed-value><stored-value>1070023</stored-value></pair>
-<pair><displayed-value>Vanderhoof, Irwin</displayed-value><stored-value>1152393</stored-value></pair>
-
-<pair><displayed-value>Vareda, Jo‚Äûo</displayed-value><stored-value>659275</stored-value></pair>
-<pair><displayed-value>Vargas, Patrick</displayed-value><stored-value>713441</stored-value></pair>
-<pair><displayed-value>Varian, Hal R.</displayed-value><stored-value>93838</stored-value></pair>
-<pair><displayed-value>Vassiliou, Yannis</displayed-value><stored-value>1143314</stored-value></pair>
-<pair><displayed-value>Vayanos, Dimitri</displayed-value><stored-value>15722</stored-value></pair>
-<pair><displayed-value>Veim, Joan C.</displayed-value><stored-value>1143346</stored-value></pair>
-
-<pair><displayed-value>Velasco, Andres</displayed-value><stored-value>1154640</stored-value></pair>
-<pair><displayed-value>Veldkamp, Laura</displayed-value><stored-value>335664</stored-value></pair>
-<pair><displayed-value>Velucchi, Margherita</displayed-value><stored-value>819458</stored-value></pair>
-<pair><displayed-value>Verdasca, Andrew</displayed-value><stored-value>681944</stored-value></pair>
-<pair><displayed-value>Verdelhan, Adrien</displayed-value><stored-value>368958</stored-value></pair>
-<pair><displayed-value>Verdier, Thierry</displayed-value><stored-value>43780</stored-value></pair>
-
-<pair><displayed-value>Veredas, David</displayed-value><stored-value>334702</stored-value></pair>
-<pair><displayed-value>Verykios, Vassilios</displayed-value><stored-value>1131959</stored-value></pair>
-<pair><displayed-value>Vessey, Iris</displayed-value><stored-value>898554</stored-value></pair>
-<pair><displayed-value>Viard, Brian</displayed-value><stored-value>1146522</stored-value></pair>
-<pair><displayed-value>Viard, V. Brian</displayed-value><stored-value>329487</stored-value></pair>
-<pair><displayed-value>Viard, V. Brian</displayed-value><stored-value>1133342</stored-value></pair>
-
-<pair><displayed-value>Viard, V.Brian</displayed-value><stored-value>1132679</stored-value></pair>
-<pair><displayed-value>Viard (Stanford), V. Brian</displayed-value><stored-value>1133344</stored-value></pair>
-<pair><displayed-value>Vigneron, Olivier</displayed-value><stored-value>379820</stored-value></pair>
-<pair><displayed-value>Vilarrubia, Josep M.</displayed-value><stored-value>522412</stored-value></pair>
-<pair><displayed-value>Villanueva, Julian</displayed-value><stored-value>112700</stored-value></pair>
-<pair><displayed-value>Vinod, Hrishikesh D.</displayed-value><stored-value>139267</stored-value></pair>
-
-<pair><displayed-value>Violante, Giovanni</displayed-value><stored-value>35267</stored-value></pair>
-<pair><displayed-value>Viscusi, W. Kip</displayed-value><stored-value>84668</stored-value></pair>
-<pair><displayed-value>Vissing-Jorgensen, Annette</displayed-value><stored-value>252314</stored-value></pair>
-<pair><displayed-value>Viswanathan, Siva</displayed-value><stored-value>340684</stored-value></pair>
-<pair><displayed-value>Viswanathan, Sivakumar</displayed-value><stored-value>1133777</stored-value></pair>
-<pair><displayed-value>Vogt, William B.</displayed-value><stored-value>83175</stored-value></pair>
-
-<pair><displayed-value>Volinsky, Chris</displayed-value><stored-value>1131954</stored-value></pair>
-<pair><displayed-value>Voronov, Artem B.</displayed-value><stored-value>540845</stored-value></pair>
-<pair><displayed-value>Vulcano, Gustavo</displayed-value><stored-value>936341</stored-value></pair>
-<pair><displayed-value>Wachtel, Paul</displayed-value><stored-value>17656</stored-value></pair>
-<pair><displayed-value>Wachter, Jessica A.</displayed-value><stored-value>159310</stored-value></pair>
-<pair><displayed-value>Wallace, Nancy E.</displayed-value><stored-value>15166</stored-value></pair>
-
-<pair><displayed-value>Wallsten, Scott</displayed-value><stored-value>203971</stored-value></pair>
-<pair><displayed-value>Walter, Ingo</displayed-value><stored-value>17591</stored-value></pair>
-<pair><displayed-value>Walton, Eric J.</displayed-value><stored-value>1142958</stored-value></pair>
-<pair><displayed-value>Wang, Cheng</displayed-value><stored-value>263888</stored-value></pair>
-<pair><displayed-value>Wang, Jiang</displayed-value><stored-value>17464</stored-value></pair>
-<pair><displayed-value>Wang, Junmin</displayed-value><stored-value>690607</stored-value></pair>
-
-<pair><displayed-value>Wang, Yi</displayed-value><stored-value>720818</stored-value></pair>
-<pair><displayed-value>Wang, Yu-Ming</displayed-value><stored-value>1135985</stored-value></pair>
-<pair><displayed-value>Ward, Michael Robert</displayed-value><stored-value>245196</stored-value></pair>
-<pair><displayed-value>Warneryd, Karl</displayed-value><stored-value>75848</stored-value></pair>
-<pair><displayed-value>Warren, David S.</displayed-value><stored-value>1143424</stored-value></pair>
-<pair><displayed-value>Watanabe, Masahiro</displayed-value><stored-value>224204</stored-value></pair>
-
-<pair><displayed-value>Weber, Bruce</displayed-value><stored-value>412896</stored-value></pair>
-<pair><displayed-value>Weber, Ron</displayed-value><stored-value>1143344</stored-value></pair>
-<pair><displayed-value>Wei, Chenyang</displayed-value><stored-value>108742</stored-value></pair>
-<pair><displayed-value>Wei, Kelsey D.</displayed-value><stored-value>651866</stored-value></pair>
-<pair><displayed-value>Wei Tang, Vicki</displayed-value><stored-value>1145078</stored-value></pair>
-<pair><displayed-value>Weidenbaum, Murray</displayed-value><stored-value>239680</stored-value></pair>
-
-<pair><displayed-value>Weigend, Andreas</displayed-value><stored-value>1510</stored-value></pair>
-<pair><displayed-value>Weill, Peter</displayed-value><stored-value>327559</stored-value></pair>
-<pair><displayed-value>Weill, Pierre-Olivier</displayed-value><stored-value>445145</stored-value></pair>
-<pair><displayed-value>Weinberg, Stephen Ernest</displayed-value><stored-value>330164</stored-value></pair>
-<pair><displayed-value>Weinstein, David E.</displayed-value><stored-value>17080</stored-value></pair>
-<pair><displayed-value>Weintraub, Gabriel Y.</displayed-value><stored-value>739931</stored-value></pair>
-
-<pair><displayed-value>Weintrop, Joseph</displayed-value><stored-value>27290</stored-value></pair>
-<pair><displayed-value>Weisbach, Michael S.</displayed-value><stored-value>1641</stored-value></pair>
-<pair><displayed-value>Weisman, Dennis</displayed-value><stored-value>71717</stored-value></pair>
-<pair><displayed-value>Weiss, Elliot</displayed-value><stored-value>1133346</stored-value></pair>
-<pair><displayed-value>Weiss, Lawrence A.</displayed-value><stored-value>21433</stored-value></pair>
-<pair><displayed-value>Weitz, Rob R.</displayed-value><stored-value>1141312</stored-value></pair>
-
-<pair><displayed-value>Wen, Zhong</displayed-value><stored-value>482952</stored-value></pair>
-<pair><displayed-value>Werker, Bas J.M.</displayed-value><stored-value>50141</stored-value></pair>
-<pair><displayed-value>Weston, J. Fred</displayed-value><stored-value>16231</stored-value></pair>
-<pair><displayed-value>White, Alan</displayed-value><stored-value>296747</stored-value></pair>
-<pair><displayed-value>White, Larry</displayed-value><stored-value>425827</stored-value></pair>
-<pair><displayed-value>White, Lawrence J.</displayed-value><stored-value>15117</stored-value></pair>
-
-<pair><displayed-value>White, Norman</displayed-value><stored-value>475367</stored-value></pair>
-<pair><displayed-value>Whitelaw, Robert F.</displayed-value><stored-value>42751</stored-value></pair>
-<pair><displayed-value>Whitson, Jennifer</displayed-value><stored-value>341652</stored-value></pair>
-<pair><displayed-value>Wiesenfeld, Batia</displayed-value><stored-value>653997</stored-value></pair>
-<pair><displayed-value>Wiggins, Steven N.</displayed-value><stored-value>535660</stored-value></pair>
-<pair><displayed-value>Wilde, Christian</displayed-value><stored-value>451705</stored-value></pair>
-
-<pair><displayed-value>Wildman, Steven S.</displayed-value><stored-value>83528</stored-value></pair>
-<pair><displayed-value>Wilhelm, William J.</displayed-value><stored-value>15853</stored-value></pair>
-<pair><displayed-value>Wilhelm Jr., William J.</displayed-value><stored-value>1151902</stored-value></pair>
-<pair><displayed-value>Wilkinson, Dennis</displayed-value><stored-value>1159559</stored-value></pair>
-<pair><displayed-value>Williams, Kristen</displayed-value><stored-value>884309</stored-value></pair>
-<pair><displayed-value>Willig, Robert D.</displayed-value><stored-value>93847</stored-value></pair>
-
-<pair><displayed-value>Wilson, Barry</displayed-value><stored-value>1154226</stored-value></pair>
-<pair><displayed-value>Windschitl, Paul D.</displayed-value><stored-value>713433</stored-value></pair>
-<pair><displayed-value>Winer, Russell</displayed-value><stored-value>333381</stored-value></pair>
-<pair><displayed-value>Wohl, Avi</displayed-value><stored-value>32069</stored-value></pair>
-<pair><displayed-value>Wolfenzon, Daniel</displayed-value><stored-value>245571</stored-value></pair>
-<pair><displayed-value>Wolfers, Justin</displayed-value><stored-value>199369</stored-value></pair>
-
-<pair><displayed-value>Wolff, Edward N.</displayed-value><stored-value>46052</stored-value></pair>
-<pair><displayed-value>Wolff, Michael C</displayed-value><stored-value>378439</stored-value></pair>
-<pair><displayed-value>Wolfram, Catherine D.</displayed-value><stored-value>17351</stored-value></pair>
-<pair><displayed-value>Woodbury, Linda</displayed-value><stored-value>229587</stored-value></pair>
-<pair><displayed-value>Working Paper Series, UPF</displayed-value><stored-value>386779</stored-value></pair>
-<pair><displayed-value>Working Papers, MIT Sloan</displayed-value><stored-value>285952</stored-value></pair>
-
-<pair><displayed-value>Wright, Charles R.</displayed-value><stored-value>383749</stored-value></pair>
-<pair><displayed-value>Wright, Charles</displayed-value><stored-value>1143032</stored-value></pair>
-<pair><displayed-value>Wright, Jonathan H.</displayed-value><stored-value>232682</stored-value></pair>
-<pair><displayed-value>Wright, Randall D.</displayed-value><stored-value>180440</stored-value></pair>
-<pair><displayed-value>Wu, D.J.</displayed-value><stored-value>704252</stored-value></pair>
-<pair><displayed-value>Wu, Guojun</displayed-value><stored-value>107650</stored-value></pair>
-
-<pair><displayed-value>Wu, Liuren</displayed-value><stored-value>381854</stored-value></pair>
-<pair><displayed-value>Wu, Min</displayed-value><stored-value>98278</stored-value></pair>
-<pair><displayed-value>Wulf, Julie M.</displayed-value><stored-value>145988</stored-value></pair>
-<pair><displayed-value>Wurgler, Je rey</displayed-value><stored-value>1148481</stored-value></pair>
-<pair><displayed-value>Wurgler, Jeffery</displayed-value><stored-value>1148143</stored-value></pair>
-<pair><displayed-value>Wurgler, Jeffrey A.</displayed-value><stored-value>174751</stored-value></pair>
-
-<pair><displayed-value>Xavier, Gabaix</displayed-value><stored-value>1147163</stored-value></pair>
-<pair><displayed-value>Xiao, Mo</displayed-value><stored-value>114943</stored-value></pair>
-<pair><displayed-value>Xiao, Xiaohong Anna</displayed-value><stored-value>437190</stored-value></pair>
-<pair><displayed-value>Xiao, Zhixing</displayed-value><stored-value>691759</stored-value></pair>
-<pair><displayed-value>Xie, Jinhong</displayed-value><stored-value>328081</stored-value></pair>
-<pair><displayed-value>Xin, Mingdi</displayed-value><stored-value>550610</stored-value></pair>
-
-<pair><displayed-value>Xiong, Wei</displayed-value><stored-value>196859</stored-value></pair>
-<pair><displayed-value>Xitco, Christopher</displayed-value><stored-value>355389</stored-value></pair>
-<pair><displayed-value>Xu, Yexiao</displayed-value><stored-value>213750</stored-value></pair>
-<pair><displayed-value>Yaari, Varda Lewinstein</displayed-value><stored-value>32059</stored-value></pair>
-<pair><displayed-value>Yadav, Pradeep K.</displayed-value><stored-value>141758</stored-value></pair>
-<pair><displayed-value>Yakov, Amihud</displayed-value><stored-value>1151293</stored-value></pair>
-
-<pair><displayed-value>Yan, Hong</displayed-value><stored-value>282808</stored-value></pair>
-<pair><displayed-value>Yang, Sha</displayed-value><stored-value>885119</stored-value></pair>
-<pair><displayed-value>Yang, Wei</displayed-value><stored-value>366166</stored-value></pair>
-<pair><displayed-value>Ye, Yinyu</displayed-value><stored-value>364213</stored-value></pair>
-<pair><displayed-value>Yellen, Janet L.</displayed-value><stored-value>328325</stored-value></pair>
-<pair><displayed-value>Yen, Benjamin P.-C.</displayed-value><stored-value>1133794</stored-value></pair>
-
-<pair><displayed-value>Yermack, David</displayed-value><stored-value>44459</stored-value></pair>
-<pair><displayed-value>Yeung, Bernard Yin</displayed-value><stored-value>71371</stored-value></pair>
-<pair><displayed-value>Yoffie, David</displayed-value><stored-value>268795</stored-value></pair>
-<pair><displayed-value>Yorukoglu, Mehmet</displayed-value><stored-value>80710</stored-value></pair>
-<pair><displayed-value>Yorulmazer, Tanju</displayed-value><stored-value>91471</stored-value></pair>
-<pair><displayed-value>Yu, George C</displayed-value><stored-value>874066</stored-value></pair>
-
-<pair><displayed-value>Yu, Lei</displayed-value><stored-value>333354</stored-value></pair>
-<pair><displayed-value>Yu, Xiaoyun</displayed-value><stored-value>170029</stored-value></pair>
-<pair><displayed-value>Yuan, Yu</displayed-value><stored-value>533582</stored-value></pair>
-<pair><displayed-value>Yun, Hayong</displayed-value><stored-value>410573</stored-value></pair>
-<pair><displayed-value>Yung, Chung</displayed-value><stored-value>1133785</stored-value></pair>
-<pair><displayed-value>Zach, Tzachi</displayed-value><stored-value>197470</stored-value></pair>
-
-<pair><displayed-value>Zacharias, Josh</displayed-value><stored-value>1146530</stored-value></pair>
-<pair><displayed-value>Zacharias, Joshua</displayed-value><stored-value>1133321</stored-value></pair>
-<pair><displayed-value>Zajonc, Peter C.</displayed-value><stored-value>1142085</stored-value></pair>
-<pair><displayed-value>Zand, Dale E.</displayed-value><stored-value>354026</stored-value></pair>
-<pair><displayed-value>Zarowin, Paul</displayed-value><stored-value>17664</stored-value></pair>
-<pair><displayed-value>Zeckhauser, Richard J.</displayed-value><stored-value>17140</stored-value></pair>
-
-<pair><displayed-value>Zeithammer, Robert</displayed-value><stored-value>333679</stored-value></pair>
-<pair><displayed-value>Zemel, Dr. Eitan</displayed-value><stored-value>1147154</stored-value></pair>
-<pair><displayed-value>Zemel, Eitan</displayed-value><stored-value>1143352</stored-value></pair>
-<pair><displayed-value>Zemsky, Peter B.</displayed-value><stored-value>21599</stored-value></pair>
-<pair><displayed-value>Zeng, Qi</displayed-value><stored-value>463465</stored-value></pair>
-<pair><displayed-value>Zghaibeh, Manaf</displayed-value><stored-value>701848</stored-value></pair>
-
-<pair><displayed-value>Zhang, Jiawei</displayed-value><stored-value>1147156</stored-value></pair>
-<pair><displayed-value>Zhang, Jie Jennifer</displayed-value><stored-value>283009</stored-value></pair>
-<pair><displayed-value>Zhang, Jin E.</displayed-value><stored-value>115795</stored-value></pair>
-<pair><displayed-value>Zhang, Xiaoquan (Michael)</displayed-value><stored-value>102553</stored-value></pair>
-<pair><displayed-value>Zhang, Z. John</displayed-value><stored-value>994223</stored-value></pair>
-<pair><displayed-value>Zhao, J. Leon</displayed-value><stored-value>1133782</stored-value></pair>
-
-<pair><displayed-value>Zhao, Minyuan</displayed-value><stored-value>565026</stored-value></pair>
-<pair><displayed-value>Zheng, Rong</displayed-value><stored-value>853994</stored-value></pair>
-<pair><displayed-value>Zhou, Chunsheng</displayed-value><stored-value>15811</stored-value></pair>
-<pair><displayed-value>Zhou, Mingming</displayed-value><stored-value>441320</stored-value></pair>
-<pair><displayed-value>Zhou, Nan</displayed-value><stored-value>44843</stored-value></pair>
-<pair><displayed-value>Zhou, Yan</displayed-value><stored-value>884393</stored-value></pair>
-
-<pair><displayed-value>Zhu, Feng</displayed-value><stored-value>400098</stored-value></pair>
-<pair><displayed-value>Zin, Stanley E.</displayed-value><stored-value>51622</stored-value></pair>
-<pair><displayed-value>Zin, Stanley E.</displayed-value><stored-value>371011</stored-value></pair>
-<pair><displayed-value>Zumbansen, Peer</displayed-value><stored-value>109516</stored-value></pair>
-<pair><displayed-value>Zur, Emanuel</displayed-value><stored-value>424195</stored-value></pair>
-<pair><displayed-value>Zweig, Dani</displayed-value><stored-value>1135986</stored-value></pair>
-
-<pair><displayed-value>and Portfolio Management, Financial Markets</displayed-value><stored-value>510373</stored-value></pair>
-<pair><displayed-value>chassagnon, virgile</displayed-value><stored-value>925887</stored-value></pair>
-<pair><displayed-value>de Castro, Rui Lu√ås</displayed-value><stored-value>334015</stored-value></pair>
-<pair><displayed-value>de Mesquita, Bruce Bueno</displayed-value><stored-value>1144332</stored-value></pair>
-<pair><displayed-value>de Vaujany, Francois-Xavier</displayed-value><stored-value>1185598</stored-value></pair>
-<pair><displayed-value>jain, pranay</displayed-value><stored-value>1033091</stored-value></pair>
-
-<pair><displayed-value>krasny, yoel</displayed-value><stored-value>655513</stored-value></pair>
-<pair><displayed-value>lchiishi, Tatsuro</displayed-value><stored-value>1141319</stored-value></pair>
-<pair><displayed-value>lgbaria, Magid</displayed-value><stored-value>1142061</stored-value></pair>
-<pair><displayed-value>lord, graham</displayed-value><stored-value>1014496</stored-value></pair>
-<pair><displayed-value>lsakowitz, Tomas</displayed-value><stored-value>1135953</stored-value></pair>
-<pair><displayed-value>ma, lan</displayed-value><stored-value>925927</stored-value></pair>
-
-<pair><displayed-value>mccabe, jennifer c</displayed-value><stored-value>1084831</stored-value></pair>
-<pair><displayed-value>murphy, frederic</displayed-value><stored-value>577407</stored-value></pair>
-<pair><displayed-value>nichols, william d</displayed-value><stored-value>578670</stored-value></pair>
-<pair><displayed-value>nye, richard b</displayed-value><stored-value>461932</stored-value></pair>
-<pair><displayed-value>of Poland, National Bank</displayed-value><stored-value>851390</stored-value></pair>
-<pair><displayed-value>sokoler, meir h</displayed-value><stored-value>1090155</stored-value></pair>
-
-<pair><displayed-value>van Binsbergen, Jules H.</displayed-value><stored-value>545907</stored-value></pair>
-<pair><displayed-value>van Heck, Eric</displayed-value><stored-value>338963</stored-value></pair>
-<pair><displayed-value>van Hemert, Otto</displayed-value><stored-value>346474</stored-value></pair>
-</value-pairs>
-<value-pairs value-pairs-name="lila_days" dc-term="relations">
-     <pair>
-       <displayed-value>N/A</displayed-value>
-       <stored-value>N/A</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day1</displayed-value>
-       <stored-value>Day1</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day2</displayed-value>
-       <stored-value>Day2</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day3</displayed-value>
-       <stored-value>Day3</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day4</displayed-value>
-       <stored-value>Day4</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day5</displayed-value>
-       <stored-value>Day5</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day6</displayed-value>
-       <stored-value>Day6</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day7</displayed-value>
-       <stored-value>Day7</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day8</displayed-value>
-       <stored-value>Day8</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day9</displayed-value>
-       <stored-value>Day9</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day10</displayed-value>
-       <stored-value>Day10</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day11</displayed-value>
-       <stored-value>Day11</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day12</displayed-value>
-       <stored-value>Day12</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day13</displayed-value>
-       <stored-value>Day13</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day14</displayed-value>
-       <stored-value>Day14</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day15</displayed-value>
-       <stored-value>Day15</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day16</displayed-value>
-       <stored-value>Day16</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day17</displayed-value>
-       <stored-value>Day17</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day18</displayed-value>
-       <stored-value>Day18</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day19</displayed-value>
-       <stored-value>Day19</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day20</displayed-value>
-       <stored-value>Day20</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day21</displayed-value>
-       <stored-value>Day21</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day22</displayed-value>
-       <stored-value>Day22</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day23</displayed-value>
-       <stored-value>Day23</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day24</displayed-value>
-       <stored-value>Day24</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day25</displayed-value>
-       <stored-value>Day25</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day26</displayed-value>
-       <stored-value>Day26</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day27</displayed-value>
-       <stored-value>Day27</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day28</displayed-value>
-       <stored-value>Day28</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day29</displayed-value>
-       <stored-value>Day29</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day30</displayed-value>
-       <stored-value>Day30</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>Day31</displayed-value>
-       <stored-value>Day31</stored-value>
-     </pair>
-</value-pairs>
-  <value-pairs value-pairs-name="gallatin_subjects" dc-term="topic">
-     <pair>
-       <displayed-value>ARTS-UG</displayed-value>
-       <stored-value>ARTS-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>CLI-UG</displayed-value>
-       <stored-value>CLI-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>CORE-GG</displayed-value>
-       <stored-value>CORE-GG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>ELEC-GG</displayed-value>
-       <stored-value>ELEC-GG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>FIRST-UG</displayed-value>
-       <stored-value>FIRST-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>IDSEM-UG</displayed-value>
-       <stored-value>IDSEM-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>PRACT-UG</displayed-value>
-       <stored-value>PRACT-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>TRAVL-UG</displayed-value>
-       <stored-value>TRAVL-UG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>TRAVL-GG</displayed-value>
-       <stored-value>TRAVL-GG</stored-value>
-     </pair>
-     <pair>
-       <displayed-value>WRTNG-UG</displayed-value>
-       <stored-value>WRTNG-UG</stored-value>
-     </pair>
-   </value-pairs>
-   <value-pairs value-pairs-name="jones_languages" dc-term="language_iso">
-       <pair>
+      <pair>
+        <displayed-value>Child</displayed-value>
+        <stored-value>child</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Geriatric</displayed-value>
+
+        <stored-value>geriatric</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Theory</displayed-value>
+        <stored-value>theory</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="music_types" dc-term="type">
+      <pair>
+        <displayed-value>Adult</displayed-value>
+        <stored-value>adult</stored-value>
+      </pair>
+    </value-pairs>
+
+    <value-pairs value-pairs-name="common_types" dc-term="type">
+      <pair>
+        <displayed-value>Animation</displayed-value>
+        <stored-value>Animation</stored-value>
+      </pair>
+      <pair>
+
+        <displayed-value>Article</displayed-value>
+        <stored-value>Article</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Book</displayed-value>
+        <stored-value>Book</stored-value>
+      </pair>
+
+      <pair>
+        <displayed-value>Book chapter</displayed-value>
+        <stored-value>Book chapter</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Dataset</displayed-value>
+        <stored-value>Dataset</stored-value>
+
+      </pair>
+      <pair>
+        <displayed-value>Document</displayed-value>
+        <stored-value>Document</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Learning Object</displayed-value>
+        <stored-value>Learning Object</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Image</displayed-value>
+
+        <stored-value>Image</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Image, 3-D</displayed-value>
+        <stored-value>Image, 3-D</stored-value>
+      </pair>
+      <pair>
+
+        <displayed-value>Map</displayed-value>
+        <stored-value>Map</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Musical Score</displayed-value>
+        <stored-value>Musical Score</stored-value>
+      </pair>
+
+      <pair>
+        <displayed-value>Plan or blueprint</displayed-value>
+        <stored-value>Plan or blueprint</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Preprint</displayed-value>
+        <stored-value>Preprint</stored-value>
+
+      </pair>
+      <pair>
+        <displayed-value>Presentation</displayed-value>
+        <stored-value>Presentation</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Recording, acoustical</displayed-value>
+
+        <stored-value>Recording, acoustical</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Recording, musical</displayed-value>
+        <stored-value>Recording, musical</stored-value>
+      </pair>
+      <pair>
+
+        <displayed-value>Recording, oral</displayed-value>
+        <stored-value>Recording, oral</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Software</displayed-value>
+        <stored-value>Software</stored-value>
+      </pair>
+
+      <pair>
+        <displayed-value>Technical Report</displayed-value>
+        <stored-value>Technical Report</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Thesis</displayed-value>
+        <stored-value>Thesis</stored-value>
+
+      </pair>
+      <pair>
+        <displayed-value>Video</displayed-value>
+        <stored-value>Video</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Working Paper</displayed-value>
+
+        <stored-value>Working Paper</stored-value>
+      </pair>
+      <pair>
+
+        <displayed-value>Other</displayed-value>
+        <stored-value>Other</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="music_lan" dc-term="language_iso">
+      <pair>
+        <displayed-value>English (United States)</displayed-value>
+        <stored-value>en_US</stored-value>
+      </pair>
+    </value-pairs>
+    <!-- default language order: (from dspace 1.2.1)
+         "en_US", "en", "es", "de", "fr", "it", "ja", "zh", "other", ""
+    -->
+    <value-pairs value-pairs-name="common_iso_languages" dc-term="language_iso">
+      <pair>
+        <displayed-value>N/A</displayed-value>
+        <stored-value></stored-value>
+      </pair>
+      <pair>
+        <displayed-value>English (United States)</displayed-value>
+        <stored-value>en_US</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>English</displayed-value>
+        <stored-value>en</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Spanish</displayed-value>
+        <stored-value>es</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>German</displayed-value>
+        <stored-value>de</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>French</displayed-value>
+        <stored-value>fr</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Italian</displayed-value>
+        <stored-value>it</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Japanese</displayed-value>
+        <stored-value>ja</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Chinese</displayed-value>
+        <stored-value>zh</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>(Other)</displayed-value>
+        <stored-value>other</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="collins_languages" dc-term="language_iso">
+      <pair>
+        <displayed-value>mls</displayed-value>
+        <stored-value>mls</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="authors_identifiers" dc-term="authorid-ssrn">
+      <pair><displayed-value>Aaker, Jennifer Lynn</displayed-value><stored-value>105813</stored-value></pair>
+      <pair><displayed-value>Abbatello, Tara</displayed-value><stored-value>331649</stored-value></pair>
+
+      <pair><displayed-value>Aboody, David</displayed-value><stored-value>62902</stored-value></pair>
+      <pair><displayed-value>Acemoglu, Daron</displayed-value><stored-value>18621</stored-value></pair>
+      <pair><displayed-value>Acharya, Viral V.</displayed-value><stored-value>142715</stored-value></pair>
+      <pair><displayed-value>Ackerberg, Daniel A.</displayed-value><stored-value>269402</stored-value></pair>
+      <pair><displayed-value>Acquisti, Alessandro</displayed-value><stored-value>57339</stored-value></pair>
+      <pair><displayed-value>Adams, Ren√àe B.</displayed-value><stored-value>248065</stored-value></pair>
+
+      <pair><displayed-value>Adler, Barry E.</displayed-value><stored-value>23066</stored-value></pair>
+      <pair><displayed-value>Adomavicius, Gediminas</displayed-value><stored-value>1131949</stored-value></pair>
+      <pair><displayed-value>Aerts, Marc</displayed-value><stored-value>1147166</stored-value></pair>
+      <pair><displayed-value>Affleck-Graves, John Felix</displayed-value><stored-value>2122</stored-value></pair>
+      <pair><displayed-value>Agarwal, Deepak</displayed-value><stored-value>593437</stored-value></pair>
+      <pair><displayed-value>Agarwal, Sumit</displayed-value><stored-value>352406</stored-value></pair>
+
+      <pair><displayed-value>Aggarwal, Rohit</displayed-value><stored-value>735974</stored-value></pair>
+      <pair><displayed-value>Agichtein, Eugene</displayed-value><stored-value>1131962</stored-value></pair>
+      <pair><displayed-value>Agrawal, Ashwini K.</displayed-value><stored-value>1126912</stored-value></pair>
+      <pair><displayed-value>Agrawal, Deepak NMI2</displayed-value><stored-value>328668</stored-value></pair>
+      <pair><displayed-value>Agrawal, Deepak</displayed-value><stored-value>1148837</stored-value></pair>
+      <pair><displayed-value>Agrawal, Nidhi</displayed-value><stored-value>699395</stored-value></pair>
+
+      <pair><displayed-value>Ahituv, Niv</displayed-value><stored-value>350466</stored-value></pair>
+      <pair><displayed-value>Ahn, Dong-Hyun</displayed-value><stored-value>32563</stored-value></pair>
+      <pair><displayed-value>Aiello, Cecilia H.</displayed-value><stored-value>753575</stored-value></pair>
+      <pair><displayed-value>Akhavein, Jalal D.</displayed-value><stored-value>16933</stored-value></pair>
+      <pair><displayed-value>Alan Bear, Larry</displayed-value><stored-value>1152957</stored-value></pair>
+      <pair><displayed-value>Alcacer, Juan</displayed-value><stored-value>269573</stored-value></pair>
+
+      <pair><displayed-value>Ali, Ashiq</displayed-value><stored-value>59239</stored-value></pair>
+      <pair><displayed-value>Allan, Eberhart</displayed-value><stored-value>1151898</stored-value></pair>
+      <pair><displayed-value>Allayannis, George S.</displayed-value><stored-value>138499</stored-value></pair>
+      <pair><displayed-value>Allen, Franklin</displayed-value><stored-value>16888</stored-value></pair>
+      <pair><displayed-value>Allen, Linda</displayed-value><stored-value>879</stored-value></pair>
+      <pair><displayed-value>Allen, William T.</displayed-value><stored-value>97908</stored-value></pair>
+
+      <pair><displayed-value>Almeid, Heitor</displayed-value><stored-value>1149003</stored-value></pair>
+      <pair><displayed-value>Almeida, Heitor</displayed-value><stored-value>49859</stored-value></pair>
+      <pair><displayed-value>Altman, Edward I.</displayed-value><stored-value>17593</stored-value></pair>
+      <pair><displayed-value>Amador, Manuel</displayed-value><stored-value>93747</stored-value></pair>
+      <pair><displayed-value>Amihud, Yakov</displayed-value><stored-value>17595</stored-value></pair>
+      <pair><displayed-value>Amir, Eli</displayed-value><stored-value>16087</stored-value></pair>
+
+      <pair><displayed-value>Amit, Eli</displayed-value><stored-value>1131109</stored-value></pair>
+      <pair><displayed-value>Ammer, John Matthew</displayed-value><stored-value>16396</stored-value></pair>
+      <pair><displayed-value>Anagnostakis, Kostas</displayed-value><stored-value>701836</stored-value></pair>
+      <pair><displayed-value>Andersen, Torben G.</displayed-value><stored-value>17696</stored-value></pair>
+      <pair><displayed-value>Anderson, Lanie</displayed-value><stored-value>359140</stored-value></pair>
+      <pair><displayed-value>Anderson, Richard G.</displayed-value><stored-value>347475</stored-value></pair>
+
+      <pair><displayed-value>Animesh, Animesh</displayed-value><stored-value>514966</stored-value></pair>
+      <pair><displayed-value>Ansari, Asim</displayed-value><stored-value>1747</stored-value></pair>
+      <pair><displayed-value>Ansari, Shahzad M.</displayed-value><stored-value>798534</stored-value></pair>
+      <pair><displayed-value>Anthony, Saunders</displayed-value><stored-value>1149005</stored-value></pair>
+      <pair><displayed-value>Arakawa, Kiyoshi</displayed-value><stored-value>680536</stored-value></pair>
+      <pair><displayed-value>Aral, Sinan</displayed-value><stored-value>110270</stored-value></pair>
+
+      <pair><displayed-value>Araman, Victor F.</displayed-value><stored-value>583956</stored-value></pair>
+      <pair><displayed-value>Archak, Nikolay</displayed-value><stored-value>884454</stored-value></pair>
+      <pair><displayed-value>Ariav, Gad</displayed-value><stored-value>350468</stored-value></pair>
+      <pair><displayed-value>Arlen, Jennifer</displayed-value><stored-value>17334</stored-value></pair>
+      <pair><displayed-value>Armony, Mor</displayed-value><stored-value>349603</stored-value></pair>
+      <pair><displayed-value>Armstrong, J. Scott</displayed-value><stored-value>116288</stored-value></pair>
+
+      <pair><displayed-value>Aron, Ravi</displayed-value><stored-value>1133974</stored-value></pair>
+      <pair><displayed-value>Arora, Neeraj NMI1</displayed-value><stored-value>268782</stored-value></pair>
+      <pair><displayed-value>Arrow, Kenneth J.</displayed-value><stored-value>93675</stored-value></pair>
+      <pair><displayed-value>Arunkundram, Ravi</displayed-value><stored-value>1133793</stored-value></pair>
+      <pair><displayed-value>Asker, Jhon</displayed-value><stored-value>1148137</stored-value></pair>
+      <pair><displayed-value>Asker, John William</displayed-value><stored-value>245091</stored-value></pair>
+
+      <pair><displayed-value>Assael, Henry</displayed-value><stored-value>713359</stored-value></pair>
+      <pair><displayed-value>Asthana, Ajay</displayed-value><stored-value>1142954</stored-value></pair>
+      <pair><displayed-value>Ater, Itai</displayed-value><stored-value>884203</stored-value></pair>
+      <pair><displayed-value>Atkins, Susannah</displayed-value><stored-value>357853</stored-value></pair>
+      <pair><displayed-value>Aue, Alexander</displayed-value><stored-value>1282745</stored-value></pair>
+      <pair><displayed-value>Azoulay, Eddy</displayed-value><stored-value>1147159</stored-value></pair>
+
+      <pair><displayed-value>B. Cabral, Luis M.</displayed-value><stored-value>1146523</stored-value></pair>
+      <pair><displayed-value>Baccara, Mariagiovanna</displayed-value><stored-value>372674</stored-value></pair>
+      <pair><displayed-value>Baccaraa, Mariagiovanna</displayed-value><stored-value>1133347</stored-value></pair>
+      <pair><displayed-value>Back, Andrew D.</displayed-value><stored-value>1133792</stored-value></pair>
+      <pair><displayed-value>Backus, David K.</displayed-value><stored-value>17597</stored-value></pair>
+      <pair><displayed-value>Bagby, John W.</displayed-value><stored-value>86167</stored-value></pair>
+
+      <pair><displayed-value>Bagchi, Rajesh</displayed-value><stored-value>665865</stored-value></pair>
+      <pair><displayed-value>Baghai, Ramin</displayed-value><stored-value>452218</stored-value></pair>
+      <pair><displayed-value>Bagozzi, Richard P.</displayed-value><stored-value>369606</stored-value></pair>
+      <pair><displayed-value>Bailey, Elizabeth E.</displayed-value><stored-value>83338</stored-value></pair>
+      <pair><displayed-value>Baily, Martin Neil</displayed-value><stored-value>99570</stored-value></pair>
+      <pair><displayed-value>Baird, Irina M.</displayed-value><stored-value>664662</stored-value></pair>
+
+      <pair><displayed-value>Baker, Malcolm P.</displayed-value><stored-value>167351</stored-value></pair>
+      <pair><displayed-value>Bakos, Yannis</displayed-value><stored-value>70468</stored-value></pair>
+      <pair><displayed-value>Balachandran, Kashi R.</displayed-value><stored-value>20870</stored-value></pair>
+      <pair><displayed-value>Balakrishnan, Karthik</displayed-value><stored-value>734368</stored-value></pair>
+      <pair><displayed-value>Balasubramanian, P. R.</displayed-value><stored-value>520447</stored-value></pair>
+      <pair><displayed-value>Balasubramanian, Sridhar</displayed-value><stored-value>349523</stored-value></pair>
+
+      <pair><displayed-value>Balasubramanian, V.</displayed-value><stored-value>1135951</stored-value></pair>
+      <pair><displayed-value>Balduzzi, Pierluigi</displayed-value><stored-value>1359</stored-value></pair>
+      <pair><displayed-value>Bali, Turan G.</displayed-value><stored-value>235620</stored-value></pair>
+      <pair><displayed-value>Ball, Ray</displayed-value><stored-value>17468</stored-value></pair>
+      <pair><displayed-value>Ballester, Marta</displayed-value><stored-value>1131117</stored-value></pair>
+      <pair><displayed-value>Ballester Casado, Marta</displayed-value><stored-value>219754</stored-value></pair>
+
+      <pair><displayed-value>Balsam, Steven</displayed-value><stored-value>28716</stored-value></pair>
+      <pair><displayed-value>Bana, Gaurav</displayed-value><stored-value>413671</stored-value></pair>
+      <pair><displayed-value>Bangia, Anil</displayed-value><stored-value>231769</stored-value></pair>
+      <pair><displayed-value>Banker, Rajiv D.</displayed-value><stored-value>16797</stored-value></pair>
+      <pair><displayed-value>Banks, Jeffrey</displayed-value><stored-value>181270</stored-value></pair>
+      <pair><displayed-value>Banner, Matthew</displayed-value><stored-value>713464</stored-value></pair>
+
+      <pair><displayed-value>Bansal, Arun</displayed-value><stored-value>1137366</stored-value></pair>
+      <pair><displayed-value>Bansal, Arun</displayed-value><stored-value>1095769</stored-value></pair>
+      <pair><displayed-value>Bar-Isaac, Heski</displayed-value><stored-value>380567</stored-value></pair>
+      <pair><displayed-value>Bar-Yosef, Sasson</displayed-value><stored-value>55919</stored-value></pair>
+      <pair><displayed-value>Baranes, Edmond</displayed-value><stored-value>381568</stored-value></pair>
+      <pair><displayed-value>Barbarino, Alessandro</displayed-value><stored-value>761685</stored-value></pair>
+
+      <pair><displayed-value>Barber, Raymond E.</displayed-value><stored-value>1143340</stored-value></pair>
+      <pair><displayed-value>Barberis, Nicholas</displayed-value><stored-value>51524</stored-value></pair>
+      <pair><displayed-value>Barclay, Michael J.</displayed-value><stored-value>16890</stored-value></pair>
+      <pair><displayed-value>Barczi, Nathan A</displayed-value><stored-value>656913</stored-value></pair>
+      <pair><displayed-value>Barone-Adesi, Giovanni</displayed-value><stored-value>12245</stored-value></pair>
+      <pair><displayed-value>Baroudi, Jack</displayed-value><stored-value>1141329</stored-value></pair>
+
+      <pair><displayed-value>Baroudi, Jack J.</displayed-value><stored-value>390343</stored-value></pair>
+      <pair><displayed-value>Baroudi, Jack Joseph</displayed-value><stored-value>1143341</stored-value></pair>
+      <pair><displayed-value>Bartov, Eli</displayed-value><stored-value>17599</stored-value></pair>
+      <pair><displayed-value>Baruch, Shmuel</displayed-value><stored-value>79677</stored-value></pair>
+      <pair><displayed-value>Basak, Suleyman</displayed-value><stored-value>16892</stored-value></pair>
+      <pair><displayed-value>Battalio, Robert H.</displayed-value><stored-value>46218</stored-value></pair>
+
+      <pair><displayed-value>Battigalli, Pierpaolo</displayed-value><stored-value>141868</stored-value></pair>
+      <pair><displayed-value>Baumol, William J.</displayed-value><stored-value>46051</stored-value></pair>
+      <pair><displayed-value>Bazerman, Max H.</displayed-value><stored-value>273075</stored-value></pair>
+      <pair><displayed-value>Bear, Larry Alan</displayed-value><stored-value>1148480</stored-value></pair>
+      <pair><displayed-value>Bear, Rita Maldonado-</displayed-value><stored-value>1151913</stored-value></pair>
+      <pair><displayed-value>Beath, Cynthia Mathis</displayed-value><stored-value>1135969</stored-value></pair>
+
+      <pair><displayed-value>Bebchuk, Lucian A.</displayed-value><stored-value>17037</stored-value></pair>
+      <pair><displayed-value>Beck, Andrew</displayed-value><stored-value>523204</stored-value></pair>
+      <pair><displayed-value>Becker, William E.</displayed-value><stored-value>76802</stored-value></pair>
+      <pair><displayed-value>Behnke, Tara</displayed-value><stored-value>199490</stored-value></pair>
+      <pair><displayed-value>Benabou, Roland</displayed-value><stored-value>45380</stored-value></pair>
+      <pair><displayed-value>Benaroch, Michel</displayed-value><stored-value>1142292</stored-value></pair>
+
+      <pair><displayed-value>Benbunan-Fich, Raquel</displayed-value><stored-value>1133790</stored-value></pair>
+      <pair><displayed-value>Beneish, Messod Daniel</displayed-value><stored-value>16194</stored-value></pair>
+      <pair><displayed-value>Bennedsen, Morten</displayed-value><stored-value>176126</stored-value></pair>
+      <pair><displayed-value>Bennett, Paul</displayed-value><stored-value>60007</stored-value></pair>
+      <pair><displayed-value>Benveniste, Lawrence M.</displayed-value><stored-value>31751</stored-value></pair>
+      <pair><displayed-value>Berd, Arthur M.</displayed-value><stored-value>437295</stored-value></pair>
+
+      <pair><displayed-value>Berger, Allen N.</displayed-value><stored-value>2141</stored-value></pair>
+      <pair><displayed-value>Berger, Gideon</displayed-value><stored-value>1141324</stored-value></pair>
+      <pair><displayed-value>Berger, Peter</displayed-value><stored-value>1153607</stored-value></pair>
+      <pair><displayed-value>Berger, Philip G.</displayed-value><stored-value>560130</stored-value></pair>
+      <pair><displayed-value>Bergstresser, Daniel B.</displayed-value><stored-value>222235</stored-value></pair>
+      <pair><displayed-value>Berkowitz, Jeremy</displayed-value><stored-value>15008</stored-value></pair>
+
+      <pair><displayed-value>Berlin, Mitchell</displayed-value><stored-value>52780</stored-value></pair>
+      <pair><displayed-value>Berlowitz, Leslie</displayed-value><stored-value>1145081</stored-value></pair>
+      <pair><displayed-value>Berman, Simeon M.</displayed-value><stored-value>1143357</stored-value></pair>
+      <pair><displayed-value>Berndt, Donald J.</displayed-value><stored-value>1135963</stored-value></pair>
+      <pair><displayed-value>Bernstein, Abraham</displayed-value><stored-value>665196</stored-value></pair>
+      <pair><displayed-value>Bertola, Giuseppe</displayed-value><stored-value>1958</stored-value></pair>
+
+      <pair><displayed-value>Bhagwati, Jagdish</displayed-value><stored-value>239710</stored-value></pair>
+      <pair><displayed-value>Bharath, Sreedhar T.</displayed-value><stored-value>303039</stored-value></pair>
+      <pair><displayed-value>Bhardwaj, Pradeep</displayed-value><stored-value>388814</stored-value></pair>
+      <pair><displayed-value>Bhasker, S.</displayed-value><stored-value>1142082</stored-value></pair>
+      <pair><displayed-value>Bhattacharjee, Sudip</displayed-value><stored-value>370225</stored-value></pair>
+      <pair><displayed-value>Bickart, Barbara A.</displayed-value><stored-value>713470</stored-value></pair>
+
+      <pair><displayed-value>Bieber, Michael</displayed-value><stored-value>1135952</stored-value></pair>
+      <pair><displayed-value>Bierens, Herman J.</displayed-value><stored-value>81119</stored-value></pair>
+      <pair><displayed-value>Biggs, John H.</displayed-value><stored-value>346528</stored-value></pair>
+      <pair><displayed-value>Bikson, Tora K.</displayed-value><stored-value>1142064</stored-value></pair>
+      <pair><displayed-value>Billings, Mary Brooke</displayed-value><stored-value>397469</stored-value></pair>
+      <pair><displayed-value>Binbasioglu, Meral</displayed-value><stored-value>582169</stored-value></pair>
+
+      <pair><displayed-value>Bisin, Alberto</displayed-value><stored-value>145796</stored-value></pair>
+      <pair><displayed-value>Bitran, Gabriel R.</displayed-value><stored-value>17385</stored-value></pair>
+      <pair><displayed-value>Bizid, Abdelhamid</displayed-value><stored-value>852207</stored-value></pair>
+      <pair><displayed-value>Bjorn-Andersen, Niels</displayed-value><stored-value>1135964</stored-value></pair>
+      <pair><displayed-value>Blake, Christopher R.</displayed-value><stored-value>58711</stored-value></pair>
+      <pair><displayed-value>Blanchard, Olivier J.</displayed-value><stored-value>21488</stored-value></pair>
+
+      <pair><displayed-value>Bloch, Michael</displayed-value><stored-value>497123</stored-value></pair>
+      <pair><displayed-value>Block, Lauren</displayed-value><stored-value>334010</stored-value></pair>
+      <pair><displayed-value>Bloomfield, Robert J.</displayed-value><stored-value>48324</stored-value></pair>
+      <pair><displayed-value>Bodnar, Gordon M.</displayed-value><stored-value>27276</stored-value></pair>
+      <pair><displayed-value>Bodoff, David</displayed-value><stored-value>1133982</stored-value></pair>
+      <pair><displayed-value>Boehmer, Ekkehart</displayed-value><stored-value>38106</stored-value></pair>
+
+      <pair><displayed-value>Bollerslev, Tim</displayed-value><stored-value>17698</stored-value></pair>
+      <pair><displayed-value>Bonime, Seth D.</displayed-value><stored-value>160259</stored-value></pair>
+      <pair><displayed-value>Bonin, John P.</displayed-value><stored-value>38364</stored-value></pair>
+      <pair><displayed-value>Bonomo, Marco</displayed-value><stored-value>49860</stored-value></pair>
+      <pair><displayed-value>Boskin, Michael J.</displayed-value><stored-value>229678</stored-value></pair>
+      <pair><displayed-value>Boudoukh, Jacob (Kobi)</displayed-value><stored-value>17601</stored-value></pair>
+
+      <pair><displayed-value>Boudry, Walter</displayed-value><stored-value>352418</stored-value></pair>
+      <pair><displayed-value>Boyko, Victor</displayed-value><stored-value>1135962</stored-value></pair>
+      <pair><displayed-value>Bradford, David F.</displayed-value><stored-value>46623</stored-value></pair>
+      <pair><displayed-value>Brady, Brooks</displayed-value><stored-value>328965</stored-value></pair>
+      <pair><displayed-value>Braguinsky, Serguey</displayed-value><stored-value>328812</stored-value></pair>
+      <pair><displayed-value>Brandenburger, Adam M.</displayed-value><stored-value>57808</stored-value></pair>
+
+      <pair><displayed-value>Brands, Simone</displayed-value><stored-value>486166</stored-value></pair>
+      <pair><displayed-value>Brandt, Michael W.</displayed-value><stored-value>161226</stored-value></pair>
+      <pair><displayed-value>Brechner, Matias</displayed-value><stored-value>447583</stored-value></pair>
+      <pair><displayed-value>Brenner, Menachem</displayed-value><stored-value>20827</stored-value></pair>
+      <pair><displayed-value>Brief, Arthur P.</displayed-value><stored-value>1142959</stored-value></pair>
+      <pair><displayed-value>Brief, Richard P.</displayed-value><stored-value>20875</stored-value></pair>
+
+      <pair><displayed-value>Brito, Jos√à Almeida</displayed-value><stored-value>1147627</stored-value></pair>
+      <pair><displayed-value>Brodsky, Julia</displayed-value><stored-value>1144328</stored-value></pair>
+      <pair><displayed-value>Bront, Juan Jose Miranda</displayed-value><stored-value>1156906</stored-value></pair>
+      <pair><displayed-value>Brown, Stephen J.</displayed-value><stored-value>2321</stored-value></pair>
+      <pair><displayed-value>Brunnermeier, Markus Konrad</displayed-value><stored-value>70328</stored-value></pair>
+      <pair><displayed-value>Brusco, Sandro</displayed-value><stored-value>365798</stored-value></pair>
+
+      <pair><displayed-value>Bryan, Stephen H.</displayed-value><stored-value>180110</stored-value></pair>
+      <pair><displayed-value>Brynjolfsson, Erik</displayed-value><stored-value>25688</stored-value></pair>
+      <pair><displayed-value>Buchanan, Bruce</displayed-value><stored-value>79838</stored-value></pair>
+      <pair><displayed-value>Buelens, Frans</displayed-value><stored-value>837464</stored-value></pair>
+      <pair><displayed-value>Bui, Tung</displayed-value><stored-value>1143313</stored-value></pair>
+      <pair><displayed-value>Burns, Patrick J.</displayed-value><stored-value>59330</stored-value></pair>
+
+      <pair><displayed-value>Burrus, Jeremy</displayed-value><stored-value>713370</stored-value></pair>
+      <pair><displayed-value>Busse, Jeffrey A.</displayed-value><stored-value>110029</stored-value></pair>
+      <pair><displayed-value>Butensky, Noah E.</displayed-value><stored-value>344407</stored-value></pair>
+      <pair><displayed-value>B¬∏lb¬∏l, Cenk</displayed-value><stored-value>712107</stored-value></pair>
+      <pair><displayed-value>CALLEN, JEFFREY L.</displayed-value><stored-value>574539</stored-value></pair>
+      <pair><displayed-value>Cabral, Luis M.B.</displayed-value><stored-value>75382</stored-value></pair>
+
+      <pair><displayed-value>Caby, Laurence</displayed-value><stored-value>1135978</stored-value></pair>
+      <pair><displayed-value>Cakici, Nusret</displayed-value><stored-value>108542</stored-value></pair>
+      <pair><displayed-value>Caldentey, Ren'e</displayed-value><stored-value>1147158</stored-value></pair>
+      <pair><displayed-value>Caldentey, Rene</displayed-value><stored-value>337731</stored-value></pair>
+      <pair><displayed-value>Caldentey, Ren√à A.</displayed-value><stored-value>1147157</stored-value></pair>
+      <pair><displayed-value>Callen, Jeffrey L.</displayed-value><stored-value>17573</stored-value></pair>
+
+      <pair><displayed-value>Calloway, Linda-Jo</displayed-value><stored-value>1142955</stored-value></pair>
+      <pair><displayed-value>Calvet, Laurent E.</displayed-value><stored-value>75695</stored-value></pair>
+      <pair><displayed-value>Camp, L. Jean</displayed-value><stored-value>262477</stored-value></pair>
+      <pair><displayed-value>Campa, Jos√à Manuel</displayed-value><stored-value>17603</stored-value></pair>
+      <pair><displayed-value>Campanale, Claudio</displayed-value><stored-value>383365</stored-value></pair>
+      <pair><displayed-value>Campanale, Claudio</displayed-value><stored-value>812500</stored-value></pair>
+
+      <pair><displayed-value>Campbell, John Y.</displayed-value><stored-value>17060</stored-value></pair>
+      <pair><displayed-value>Campello, Murillo</displayed-value><stored-value>107816</stored-value></pair>
+      <pair><displayed-value>Canals, Claudia</displayed-value><stored-value>385772</stored-value></pair>
+      <pair><displayed-value>Canina, Linda</displayed-value><stored-value>353639</stored-value></pair>
+      <pair><displayed-value>Cantillon, Estelle</displayed-value><stored-value>265156</stored-value></pair>
+      <pair><displayed-value>Capkun, Vedran</displayed-value><stored-value>429781</stored-value></pair>
+
+      <pair><displayed-value>Cappiello, Lorenzo</displayed-value><stored-value>234084</stored-value></pair>
+      <pair><displayed-value>Caprio, Gerard Jr.</displayed-value><stored-value>1152395</stored-value></pair>
+      <pair><displayed-value>Carcello, Joseph V.</displayed-value><stored-value>47320</stored-value></pair>
+      <pair><displayed-value>Carhart, Mark M.</displayed-value><stored-value>36900</stored-value></pair>
+      <pair><displayed-value>Carmel, Judith Rachelle</displayed-value><stored-value>384509</stored-value></pair>
+      <pair><displayed-value>Carpenter, Jennifer N.</displayed-value><stored-value>17605</stored-value></pair>
+
+      <pair><displayed-value>Carr, Peter P.</displayed-value><stored-value>707</stored-value></pair>
+      <pair><displayed-value>Carter, Karen</displayed-value><stored-value>387943</stored-value></pair>
+      <pair><displayed-value>Caruana, Guillermo</displayed-value><stored-value>333919</stored-value></pair>
+      <pair><displayed-value>Casadesus-Masanell, Ramon</displayed-value><stored-value>231841</stored-value></pair>
+      <pair><displayed-value>Castro, Rui</displayed-value><stored-value>947502</stored-value></pair>
+      <pair><displayed-value>Caucutt, Elizabeth M.</displayed-value><stored-value>274874</stored-value></pair>
+
+      <pair><displayed-value>Cavusoglu, Hasan</displayed-value><stored-value>803558</stored-value></pair>
+      <pair><displayed-value>Cavusoglu, Huseyin</displayed-value><stored-value>422930</stored-value></pair>
+      <pair><displayed-value>Cays, Stephen E.</displayed-value><stored-value>1133337</stored-value></pair>
+      <pair><displayed-value>Cebenoyan, A. Sinan</displayed-value><stored-value>1148426</stored-value></pair>
+      <pair><displayed-value>Cebenoyan, Fatma</displayed-value><stored-value>404843</stored-value></pair>
+      <pair><displayed-value>Chacko, George</displayed-value><stored-value>195217</stored-value></pair>
+
+      <pair><displayed-value>Chakravarti, Amitav</displayed-value><stored-value>473669</stored-value></pair>
+      <pair><displayed-value>Chambers, John R.</displayed-value><stored-value>713434</stored-value></pair>
+      <pair><displayed-value>Chan, Justin Sai-Pang</displayed-value><stored-value>400437</stored-value></pair>
+      <pair><displayed-value>Chanda, Ananda</displayed-value><stored-value>456963</stored-value></pair>
+      <pair><displayed-value>Chandon, Pierre</displayed-value><stored-value>109253</stored-value></pair>
+      <pair><displayed-value>Chandra, Ambarish</displayed-value><stored-value>810291</stored-value></pair>
+
+      <pair><displayed-value>Chang, Elaine</displayed-value><stored-value>569920</stored-value></pair>
+      <pair><displayed-value>Chang, P.H. Kevin</displayed-value><stored-value>53300</stored-value></pair>
+      <pair><displayed-value>Chang, Roberto</displayed-value><stored-value>48780</stored-value></pair>
+      <pair><displayed-value>Chapman, David A.</displayed-value><stored-value>17462</stored-value></pair>
+      <pair><displayed-value>Chay, J. B.</displayed-value><stored-value>1151309</stored-value></pair>
+      <pair><displayed-value>Checroun, Alain</displayed-value><stored-value>1143317</stored-value></pair>
+
+      <pair><displayed-value>Cheema, Amar</displayed-value><stored-value>385546</stored-value></pair>
+      <pair><displayed-value>Chemla, Gilles</displayed-value><stored-value>22734</stored-value></pair>
+      <pair><displayed-value>Chemmanur, Thomas J.</displayed-value><stored-value>16097</stored-value></pair>
+      <pair><displayed-value>Chen, Hsinchun</displayed-value><stored-value>636787</stored-value></pair>
+      <pair><displayed-value>Chen, Pei-Yu</displayed-value><stored-value>370962</stored-value></pair>
+      <pair><displayed-value>Chen, Willa W</displayed-value><stored-value>481802</stored-value></pair>
+
+      <pair><displayed-value>Chen, Xiaohong</displayed-value><stored-value>30333</stored-value></pair>
+      <pair><displayed-value>Chen, Xin</displayed-value><stored-value>1147510</stored-value></pair>
+      <pair><displayed-value>Chen, Yeh-Ning</displayed-value><stored-value>136397</stored-value></pair>
+      <pair><displayed-value>Chen, Yehning</displayed-value><stored-value>449212</stored-value></pair>
+      <pair><displayed-value>Chen, Yongmin</displayed-value><stored-value>49472</stored-value></pair>
+      <pair><displayed-value>Chen, Yuxin</displayed-value><stored-value>67048</stored-value></pair>
+
+      <pair><displayed-value>Chiang, Eric P.</displayed-value><stored-value>640314</stored-value></pair>
+      <pair><displayed-value>Chib, Siddhartha</displayed-value><stored-value>44961</stored-value></pair>
+      <pair><displayed-value>Chidambaran, N. K.</displayed-value><stored-value>15983</stored-value></pair>
+      <pair><displayed-value>Ching, Andrew</displayed-value><stored-value>609077</stored-value></pair>
+      <pair><displayed-value>Chinn, Menzie David</displayed-value><stored-value>15131</stored-value></pair>
+      <pair><displayed-value>Chiou, Ingyu</displayed-value><stored-value>113540</stored-value></pair>
+
+      <pair><displayed-value>Cho, Jang-Ok</displayed-value><stored-value>84428</stored-value></pair>
+      <pair><displayed-value>Cho, Junghoo</displayed-value><stored-value>1131961</stored-value></pair>
+      <pair><displayed-value>Choi, Frederick D.S.</displayed-value><stored-value>20881</stored-value></pair>
+      <pair><displayed-value>Choi, Jay Pil</displayed-value><stored-value>16079</stored-value></pair>
+      <pair><displayed-value>Chokshi, Narendra</displayed-value><stored-value>1133324</stored-value></pair>
+      <pair><displayed-value>Chou, Dashin</displayed-value><stored-value>1133786</stored-value></pair>
+
+      <pair><displayed-value>Choudhary, Vidyanand</displayed-value><stored-value>331630</stored-value></pair>
+      <pair><displayed-value>Christoffersen, Peter</displayed-value><stored-value>39700</stored-value></pair>
+      <pair><displayed-value>Christou, Nicolas</displayed-value><stored-value>1144329</stored-value></pair>
+      <pair><displayed-value>Chugh, Dolly</displayed-value><stored-value>327840</stored-value></pair>
+      <pair><displayed-value>Chung, Wilbur C.</displayed-value><stored-value>269571</stored-value></pair>
+      <pair><displayed-value>Ciarreta, Aitor</displayed-value><stored-value>884350</stored-value></pair>
+
+      <pair><displayed-value>Ciborra, Claudio</displayed-value><stored-value>677721</stored-value></pair>
+      <pair><displayed-value>Cicchetti, Charles J.</displayed-value><stored-value>908477</stored-value></pair>
+      <pair><displayed-value>Ciftci, Mustafa</displayed-value><stored-value>405203</stored-value></pair>
+      <pair><displayed-value>Cipollini, Fabrizio</displayed-value><stored-value>708630</stored-value></pair>
+      <pair><displayed-value>Clarke, Colin P</displayed-value><stored-value>394079</stored-value></pair>
+      <pair><displayed-value>Clayton, Matthew J.</displayed-value><stored-value>20835</stored-value></pair>
+
+      <pair><displayed-value>Clayton, Matthew</displayed-value><stored-value>1148834</stored-value></pair>
+      <pair><displayed-value>Clearwater, Scott</displayed-value><stored-value>1133774</stored-value></pair>
+      <pair><displayed-value>Clementi, Gian Luca</displayed-value><stored-value>328593</stored-value></pair>
+      <pair><displayed-value>Clemons, Eric K.</displayed-value><stored-value>17523</stored-value></pair>
+      <pair><displayed-value>Clifford, James</displayed-value><stored-value>1133955</stored-value></pair>
+      <pair><displayed-value>Clifford, Jim</displayed-value><stored-value>1143321</stored-value></pair>
+
+      <pair><displayed-value>Cohen, Daniel A.</displayed-value><stored-value>118206</stored-value></pair>
+      <pair><displayed-value>Colacito, Riccardo</displayed-value><stored-value>698614</stored-value></pair>
+      <pair><displayed-value>Cole, Rebel A.</displayed-value><stored-value>15769</stored-value></pair>
+      <pair><displayed-value>Collard-Wexler, Allan</displayed-value><stored-value>810290</stored-value></pair>
+      <pair><displayed-value>College of Business Administration, UIC</displayed-value><stored-value>1137857</stored-value></pair>
+      <pair><displayed-value>Comer, George</displayed-value><stored-value>363573</stored-value></pair>
+
+      <pair><displayed-value>Comin, Diego</displayed-value><stored-value>105076</stored-value></pair>
+      <pair><displayed-value>Commer, George</displayed-value><stored-value>328663</stored-value></pair>
+      <pair><displayed-value>Com√ån, Diego</displayed-value><stored-value>1154638</stored-value></pair>
+      <pair><displayed-value>Cooke, Alan D.J.</displayed-value><stored-value>62935</stored-value></pair>
+      <pair><displayed-value>Cooke, Diane</displayed-value><stored-value>1149823</stored-value></pair>
+      <pair><displayed-value>Cooley, Thomas F.</displayed-value><stored-value>17456</stored-value></pair>
+
+      <pair><displayed-value>Cooperman, Elizabeth S.</displayed-value><stored-value>124770</stored-value></pair>
+      <pair><displayed-value>Coplan, Judson L</displayed-value><stored-value>572447</stored-value></pair>
+      <pair><displayed-value>Corfman, Kim</displayed-value><stored-value>390835</stored-value></pair>
+      <pair><displayed-value>Cornelli, Francesca</displayed-value><stored-value>1452</stored-value></pair>
+      <pair><displayed-value>Cornett, Marcia Millon</displayed-value><stored-value>1149013</stored-value></pair>
+      <pair><displayed-value>Corsetti, Giancarlo</displayed-value><stored-value>1363</stored-value></pair>
+
+      <pair><displayed-value>Corts, Kenneth S.</displayed-value><stored-value>60589</stored-value></pair>
+      <pair><displayed-value>Cox, James C.</displayed-value><stored-value>32930</stored-value></pair>
+      <pair><displayed-value>Craig, Charles Samuel</displayed-value><stored-value>52797</stored-value></pair>
+      <pair><displayed-value>Cramton, Peter C.</displayed-value><stored-value>146596</stored-value></pair>
+      <pair><displayed-value>Crandall, Robert</displayed-value><stored-value>256044</stored-value></pair>
+      <pair><displayed-value>Cranor, Lorrie Faith</displayed-value><stored-value>333622</stored-value></pair>
+
+      <pair><displayed-value>Cremers, K.J. Martijn</displayed-value><stored-value>254417</stored-value></pair>
+      <pair><displayed-value>Creus Mir, Albert</displayed-value><stored-value>701980</stored-value></pair>
+      <pair><displayed-value>Creutz, Douglas</displayed-value><stored-value>1133332</stored-value></pair>
+      <pair><displayed-value>Croce, Mariano Massimiliano</displayed-value><stored-value>571252</stored-value></pair>
+      <pair><displayed-value>Croker, Albert</displayed-value><stored-value>447151</stored-value></pair>
+      <pair><displayed-value>Cropper, Maureen L.</displayed-value><stored-value>224652</stored-value></pair>
+
+      <pair><displayed-value>Crowley, Gwyneth</displayed-value><stored-value>63988</stored-value></pair>
+      <pair><displayed-value>Cunat, Vicente</displayed-value><stored-value>653515</stored-value></pair>
+      <pair><displayed-value>Cusick, Philip</displayed-value><stored-value>344409</stored-value></pair>
+      <pair><displayed-value>Cuyvers, Ludo</displayed-value><stored-value>1148135</stored-value></pair>
+      <pair><displayed-value>Dafria, Ashish</displayed-value><stored-value>1133333</stored-value></pair>
+      <pair><displayed-value>Dahiya, Sandeep</displayed-value><stored-value>231384</stored-value></pair>
+
+      <pair><displayed-value>Dahiyaa, Sandeep</displayed-value><stored-value>1145077</stored-value></pair>
+      <pair><displayed-value>Dahleh, Munther</displayed-value><stored-value>1033602</stored-value></pair>
+      <pair><displayed-value>Dai, Qiang</displayed-value><stored-value>139423</stored-value></pair>
+      <pair><displayed-value>Dai, Qiang</displayed-value><stored-value>1098860</stored-value></pair>
+      <pair><displayed-value>Daines, Robert</displayed-value><stored-value>181293</stored-value></pair>
+      <pair><displayed-value>Daly, George</displayed-value><stored-value>82782</stored-value></pair>
+
+      <pair><displayed-value>Damodaran, Aswath</displayed-value><stored-value>20838</stored-value></pair>
+      <pair><displayed-value>Darrough, Masako N.</displayed-value><stored-value>16153</stored-value></pair>
+      <pair><displayed-value>Das, Sanjiv Ranjan</displayed-value><stored-value>17108</stored-value></pair>
+      <pair><displayed-value>David, Backus</displayed-value><stored-value>1151295</stored-value></pair>
+      <pair><displayed-value>David, Yermack</displayed-value><stored-value>1152401</stored-value></pair>
+      <pair><displayed-value>Davidenko, Nicolas</displayed-value><stored-value>845619</stored-value></pair>
+
+      <pair><displayed-value>Davis Hodder, Leslie D.</displayed-value><stored-value>214480</stored-value></pair>
+      <pair><displayed-value>De Loecker, Jan</displayed-value><stored-value>362360</stored-value></pair>
+      <pair><displayed-value>DeLong, Gayle L.</displayed-value><stored-value>261582</stored-value></pair>
+      <pair><displayed-value>DeLongb, Gayle L.</displayed-value><stored-value>1148140</stored-value></pair>
+      <pair><displayed-value>DeMarzo, Peter M.</displayed-value><stored-value>17717</stored-value></pair>
+      <pair><displayed-value>DeMuth, Christopher</displayed-value><stored-value>233599</stored-value></pair>
+
+      <pair><displayed-value>DeYoung, Robert</displayed-value><stored-value>2280</stored-value></pair>
+      <pair><displayed-value>Dellarocas, Chrysanthos N.</displayed-value><stored-value>25705</stored-value></pair>
+      <pair><displayed-value>Demers, Elizabeth A.</displayed-value><stored-value>47023</stored-value></pair>
+      <pair><displayed-value>Demsetz, Harold</displayed-value><stored-value>93805</stored-value></pair>
+      <pair><displayed-value>Denrell, Jerker</displayed-value><stored-value>557026</stored-value></pair>
+      <pair><displayed-value>Deo, Rohit</displayed-value><stored-value>683519</stored-value></pair>
+
+      <pair><displayed-value>Dermody, Jaime Cuevas</displayed-value><stored-value>1153783</stored-value></pair>
+      <pair><displayed-value>Deuskar, Prachi</displayed-value><stored-value>352440</stored-value></pair>
+      <pair><displayed-value>Dew, Jeven</displayed-value><stored-value>673016</stored-value></pair>
+      <pair><displayed-value>Dey, Aiyesha</displayed-value><stored-value>118212</stored-value></pair>
+      <pair><displayed-value>Dezso, Cristian L.</displayed-value><stored-value>467267</stored-value></pair>
+      <pair><displayed-value>Dhar, Ravi</displayed-value><stored-value>194452</stored-value></pair>
+
+      <pair><displayed-value>Dhar, Vasant</displayed-value><stored-value>402993</stored-value></pair>
+      <pair><displayed-value>Dholakia, Utpal M.</displayed-value><stored-value>107512</stored-value></pair>
+      <pair><displayed-value>Diamond, Lester</displayed-value><stored-value>1142949</stored-value></pair>
+      <pair><displayed-value>Diaz, Alicia</displayed-value><stored-value>1135958</stored-value></pair>
+      <pair><displayed-value>Dick, Astrid Andrea</displayed-value><stored-value>47137</stored-value></pair>
+      <pair><displayed-value>Diebold, Francis X.</displayed-value><stored-value>15004</stored-value></pair>
+
+      <pair><displayed-value>Ding, Yufeng</displayed-value><stored-value>1147168</stored-value></pair>
+      <pair><displayed-value>Ding, Zhuanxin</displayed-value><stored-value>1148829</stored-value></pair>
+      <pair><displayed-value>Doan, Anhai</displayed-value><stored-value>1131967</stored-value></pair>
+      <pair><displayed-value>Dontoh, Alex</displayed-value><stored-value>20883</stored-value></pair>
+      <pair><displayed-value>Douglas, Jason</displayed-value><stored-value>656933</stored-value></pair>
+      <pair><displayed-value>Douglas, Susan</displayed-value><stored-value>333320</stored-value></pair>
+
+      <pair><displayed-value>Doukas, John A.</displayed-value><stored-value>54251</stored-value></pair>
+      <pair><displayed-value>Dreze, Xavier</displayed-value><stored-value>703349</stored-value></pair>
+      <pair><displayed-value>Driscoll, John C.</displayed-value><stored-value>173992</stored-value></pair>
+      <pair><displayed-value>Dubin, Jeffrey A.</displayed-value><stored-value>181569</stored-value></pair>
+      <pair><displayed-value>Duffie, Darrell</displayed-value><stored-value>829363</stored-value></pair>
+      <pair><displayed-value>Duliba, Katherine A.</displayed-value><stored-value>1135950</stored-value></pair>
+
+      <pair><displayed-value>Dunning, David</displayed-value><stored-value>300351</stored-value></pair>
+      <pair><displayed-value>Durnev, Artyom</displayed-value><stored-value>257034</stored-value></pair>
+      <pair><displayed-value>Durtschi, Cindy</displayed-value><stored-value>253409</stored-value></pair>
+      <pair><displayed-value>Dutta, Prajit K.</displayed-value><stored-value>53700</stored-value></pair>
+      <pair><displayed-value>Dwyer, Mark</displayed-value><stored-value>90068</stored-value></pair>
+      <pair><displayed-value>Dybvig, Philip H.</displayed-value><stored-value>56096</stored-value></pair>
+
+      <pair><displayed-value>Dyreson, Curtis</displayed-value><stored-value>1135948</stored-value></pair>
+      <pair><displayed-value>E. Sokalska, Magdalena</displayed-value><stored-value>1147621</stored-value></pair>
+      <pair><displayed-value>Eads, George</displayed-value><stored-value>711493</stored-value></pair>
+      <pair><displayed-value>Easley, David</displayed-value><stored-value>58370</stored-value></pair>
+      <pair><displayed-value>Economics Department, UCSC</displayed-value><stored-value>356535</stored-value></pair>
+      <pair><displayed-value>Economides, Nicholas</displayed-value><stored-value>1720</stored-value></pair>
+
+      <pair><displayed-value>Eden, Yoram</displayed-value><stored-value>1142948</stored-value></pair>
+      <pair><displayed-value>Editor, JOIM</displayed-value><stored-value>363704</stored-value></pair>
+      <pair><displayed-value>Edmans, Alex</displayed-value><stored-value>393296</stored-value></pair>
+      <pair><displayed-value>Edmond, Chris</displayed-value><stored-value>266360</stored-value></pair>
+      <pair><displayed-value>Ehrlinger, Joyce</displayed-value><stored-value>713456</stored-value></pair>
+      <pair><displayed-value>Eisenach, Jeffrey A.</displayed-value><stored-value>827975</stored-value></pair>
+
+      <pair><displayed-value>Eisner, Alan B</displayed-value><stored-value>620510</stored-value></pair>
+      <pair><displayed-value>El Barmi, Hammou</displayed-value><stored-value>1144327</stored-value></pair>
+      <pair><displayed-value>Eldor, Rafi</displayed-value><stored-value>1153785</stored-value></pair>
+      <pair><displayed-value>Elera, Nancy</displayed-value><stored-value>114544</stored-value></pair>
+      <pair><displayed-value>Elmagarmid, Ahmed</displayed-value><stored-value>1131958</stored-value></pair>
+      <pair><displayed-value>Elton, Edwin J.</displayed-value><stored-value>17581</stored-value></pair>
+
+      <pair><displayed-value>Elzinga, Kenneth G.</displayed-value><stored-value>329167</stored-value></pair>
+      <pair><displayed-value>Emre, Onsel</displayed-value><stored-value>368724</stored-value></pair>
+      <pair><displayed-value>Engle, Robert F.</displayed-value><stored-value>16242</stored-value></pair>
+      <pair><displayed-value>Eom, Young Ho</displayed-value><stored-value>104388</stored-value></pair>
+      <pair><displayed-value>Erdem, Tulin</displayed-value><stored-value>760817</stored-value></pair>
+      <pair><displayed-value>Evans, Matt</displayed-value><stored-value>713386</stored-value></pair>
+
+      <pair><displayed-value>Fairlie, Robert W.</displayed-value><stored-value>457</stored-value></pair>
+      <pair><displayed-value>Faktorovich, Mark</displayed-value><stored-value>1133322</stored-value></pair>
+      <pair><displayed-value>Fan, Zhenhong</displayed-value><stored-value>1145634</stored-value></pair>
+      <pair><displayed-value>Fang, Christina</displayed-value><stored-value>361860</stored-value></pair>
+      <pair><displayed-value>Farhi, Emmanuel</displayed-value><stored-value>296514</stored-value></pair>
+      <pair><displayed-value>Farnsworth, Heber</displayed-value><stored-value>20154</stored-value></pair>
+
+      <pair><displayed-value>Fat¬∑s, Enrique</displayed-value><stored-value>260988</stored-value></pair>
+      <pair><displayed-value>Faulhaber, Gerald R.</displayed-value><stored-value>17516</stored-value></pair>
+      <pair><displayed-value>Faurel, Lucile</displayed-value><stored-value>440412</stored-value></pair>
+      <pair><displayed-value>Favilukis, Jack Y</displayed-value><stored-value>696288</stored-value></pair>
+      <pair><displayed-value>Fehrs, Donald H.</displayed-value><stored-value>1153784</stored-value></pair>
+      <pair><displayed-value>Feld, Scott L</displayed-value><stored-value>1145079</stored-value></pair>
+
+      <pair><displayed-value>Feldman, Ronen</displayed-value><stored-value>343970</stored-value></pair>
+      <pair><displayed-value>Feldman, Ronen</displayed-value><stored-value>605313</stored-value></pair>
+      <pair><displayed-value>Ferguson, Niall</displayed-value><stored-value>433226</stored-value></pair>
+      <pair><displayed-value>Fernandez, Raquel</displayed-value><stored-value>42714</stored-value></pair>
+      <pair><displayed-value>Fernando, Chitru S.</displayed-value><stored-value>21888</stored-value></pair>
+      <pair><displayed-value>Ferreira, Daniel</displayed-value><stored-value>327077</stored-value></pair>
+
+      <pair><displayed-value>Ferstenberg, Robert</displayed-value><stored-value>610529</stored-value></pair>
+      <pair><displayed-value>Fessel, Florian</displayed-value><stored-value>713436</stored-value></pair>
+      <pair><displayed-value>Figlewski, Stephen</displayed-value><stored-value>17609</stored-value></pair>
+      <pair><displayed-value>Figueroa, Nicol¬∑s</displayed-value><stored-value>1133565</stored-value></pair>
+      <pair><displayed-value>Finch, Nigel</displayed-value><stored-value>438461</stored-value></pair>
+      <pair><displayed-value>Finin, Tim</displayed-value><stored-value>1142950</stored-value></pair>
+
+      <pair><displayed-value>Fish, Michael</displayed-value><stored-value>661974</stored-value></pair>
+      <pair><displayed-value>Fisher, Adlai J.</displayed-value><stored-value>75693</stored-value></pair>
+      <pair><displayed-value>Fisher, Eric</displayed-value><stored-value>1142312</stored-value></pair>
+      <pair><displayed-value>Fisher, Franklin M.</displayed-value><stored-value>21504</stored-value></pair>
+      <pair><displayed-value>Fisher, Marshall</displayed-value><stored-value>872814</stored-value></pair>
+      <pair><displayed-value>Fitch, Eliezer M.</displayed-value><stored-value>1146527</stored-value></pair>
+
+      <pair><displayed-value>Flamm, Kenneth</displayed-value><stored-value>337784</stored-value></pair>
+      <pair><displayed-value>Floyd, Barry</displayed-value><stored-value>1142079</stored-value></pair>
+      <pair><displayed-value>Fluck, Zsuzsanna</displayed-value><stored-value>17660</stored-value></pair>
+      <pair><displayed-value>Flyer, Fredrick</displayed-value><stored-value>20756</stored-value></pair>
+      <pair><displayed-value>Fogli, Alessandra</displayed-value><stored-value>333202</stored-value></pair>
+      <pair><displayed-value>Foley, C. Fritz</displayed-value><stored-value>285633</stored-value></pair>
+
+      <pair><displayed-value>Fong, Christina M.</displayed-value><stored-value>335141</stored-value></pair>
+      <pair><displayed-value>Foresi, Foresi</displayed-value><stored-value>1152955</stored-value></pair>
+      <pair><displayed-value>Foresi, Silverio</displayed-value><stored-value>1350</stored-value></pair>
+      <pair><displayed-value>Forman, Chris</displayed-value><stored-value>97179</stored-value></pair>
+      <pair><displayed-value>Foster, Joseph A.</displayed-value><stored-value>634167</stored-value></pair>
+      <pair><displayed-value>Fox, Jeremy T.</displayed-value><stored-value>416205</stored-value></pair>
+
+      <pair><displayed-value>Fraiberger, Samuel P.</displayed-value><stored-value>1210063</stored-value></pair>
+      <pair><displayed-value>Frame, W. Scott</displayed-value><stored-value>275524</stored-value></pair>
+      <pair><displayed-value>Frame, W.Scott</displayed-value><stored-value>1146520</stored-value></pair>
+      <pair><displayed-value>Francis, Bill B.</displayed-value><stored-value>53722</stored-value></pair>
+      <pair><displayed-value>Franke, G unter</displayed-value><stored-value>1148486</stored-value></pair>
+      <pair><displayed-value>Franke, G.</displayed-value><stored-value>1148473</stored-value></pair>
+
+      <pair><displayed-value>Franke, Guntar</displayed-value><stored-value>1150540</stored-value></pair>
+      <pair><displayed-value>Franke, Gunter</displayed-value><stored-value>1151899</stored-value></pair>
+      <pair><displayed-value>Franke, G¬∏nter</displayed-value><stored-value>1151916</stored-value></pair>
+      <pair><displayed-value>Frankel, Richard M.</displayed-value><stored-value>16714</stored-value></pair>
+      <pair><displayed-value>Fraser, Thomas L.</displayed-value><stored-value>805763</stored-value></pair>
+      <pair><displayed-value>Freeman, Seth</displayed-value><stored-value>369890</stored-value></pair>
+
+      <pair><displayed-value>Fried, Dov</displayed-value><stored-value>880474</stored-value></pair>
+      <pair><displayed-value>Fried, Haim Dov</displayed-value><stored-value>141200</stored-value></pair>
+      <pair><displayed-value>Friedman, Milton</displayed-value><stored-value>711499</stored-value></pair>
+      <pair><displayed-value>Friewald, Nils</displayed-value><stored-value>1291613</stored-value></pair>
+      <pair><displayed-value>Frijnsy, Bart</displayed-value><stored-value>1151301</stored-value></pair>
+      <pair><displayed-value>Frydman, Halina</displayed-value><stored-value>278768</stored-value></pair>
+
+      <pair><displayed-value>Frydman, Roman</displayed-value><stored-value>17611</stored-value></pair>
+      <pair><displayed-value>Gabaix, Xavier</displayed-value><stored-value>297281</stored-value></pair>
+      <pair><displayed-value>Gabudean, Radu</displayed-value><stored-value>510080</stored-value></pair>
+      <pair><displayed-value>Gal-Or, Esther</displayed-value><stored-value>103522</stored-value></pair>
+      <pair><displayed-value>Galai, Dan</displayed-value><stored-value>55762</stored-value></pair>
+      <pair><displayed-value>Galak, Jeff</displayed-value><stored-value>689111</stored-value></pair>
+
+      <pair><displayed-value>Gale, Douglas M.</displayed-value><stored-value>46424</stored-value></pair>
+      <pair><displayed-value>Galinsky, Adam D.</displayed-value><stored-value>327420</stored-value></pair>
+      <pair><displayed-value>Gallagher, David R.</displayed-value><stored-value>114371</stored-value></pair>
+      <pair><displayed-value>Gallier, Jean H.</displayed-value><stored-value>1142077</stored-value></pair>
+      <pair><displayed-value>Gallivan, Michael J.</displayed-value><stored-value>1141327</stored-value></pair>
+      <pair><displayed-value>Gallo, Giampiero M.</displayed-value><stored-value>140132</stored-value></pair>
+
+      <pair><displayed-value>Gande, Amar</displayed-value><stored-value>52300</stored-value></pair>
+      <pair><displayed-value>Gander, Amar</displayed-value><stored-value>1151904</stored-value></pair>
+      <pair><displayed-value>Gantman, Nataly</displayed-value><stored-value>415887</stored-value></pair>
+      <pair><displayed-value>Ganuza, Juanjo</displayed-value><stored-value>1133341</stored-value></pair>
+      <pair><displayed-value>Gao, Bin</displayed-value><stored-value>740</stored-value></pair>
+      <pair><displayed-value>Garbade, Kenneth</displayed-value><stored-value>128679</stored-value></pair>
+
+      <pair><displayed-value>Garcia Gallego, Maria Aurora</displayed-value><stored-value>260610</stored-value></pair>
+      <pair><displayed-value>Garcia-Ayuso, Manuel</displayed-value><stored-value>352881</stored-value></pair>
+      <pair><displayed-value>Garleanu, Nicolae Bogdan</displayed-value><stored-value>267236</stored-value></pair>
+      <pair><displayed-value>Garud, Raghu</displayed-value><stored-value>101761</stored-value></pair>
+      <pair><displayed-value>Gau, Yin-Feng</displayed-value><stored-value>47240</stored-value></pair>
+      <pair><displayed-value>Gaur, Vishal</displayed-value><stored-value>1111834</stored-value></pair>
+
+      <pair><displayed-value>Gautier, Axel</displayed-value><stored-value>240126</stored-value></pair>
+      <pair><displayed-value>Gavazza, Alessandro</displayed-value><stored-value>492846</stored-value></pair>
+      <pair><displayed-value>Gavious, Arieh</displayed-value><stored-value>162408</stored-value></pair>
+      <pair><displayed-value>Gavish, Bezalel</displayed-value><stored-value>793824</stored-value></pair>
+      <pair><displayed-value>Gaynor, Martin S.</displayed-value><stored-value>66276</stored-value></pair>
+      <pair><displayed-value>Gelb, David S.</displayed-value><stored-value>199549</stored-value></pair>
+
+      <pair><displayed-value>Georgantzis, Nikolaos</displayed-value><stored-value>260609</stored-value></pair>
+      <pair><displayed-value>Gertler, Mark</displayed-value><stored-value>62909</stored-value></pair>
+      <pair><displayed-value>Gervais, Simon</displayed-value><stored-value>36778</stored-value></pair>
+      <pair><displayed-value>Ghose, Anindya</displayed-value><stored-value>331629</stored-value></pair>
+      <pair><displayed-value>Ghosh, Avijit</displayed-value><stored-value>92416</stored-value></pair>
+      <pair><displayed-value>Ghysels, Eric</displayed-value><stored-value>98666</stored-value></pair>
+
+      <pair><displayed-value>Gilbert, Richard J.</displayed-value><stored-value>20576</stored-value></pair>
+      <pair><displayed-value>Gilchrist, Simon</displayed-value><stored-value>113569</stored-value></pair>
+      <pair><displayed-value>Gille, Michel</displayed-value><stored-value>1148482</stored-value></pair>
+      <pair><displayed-value>Giloni, A.</displayed-value><stored-value>1144325</stored-value></pair>
+      <pair><displayed-value>Giloni, Avi</displayed-value><stored-value>1147169</stored-value></pair>
+      <pair><displayed-value>Ginsberg, Ari</displayed-value><stored-value>101837</stored-value></pair>
+
+      <pair><displayed-value>Ginsburg, Mark</displayed-value><stored-value>415924</stored-value></pair>
+      <pair><displayed-value>Ginzberg, Michael</displayed-value><stored-value>358171</stored-value></pair>
+      <pair><displayed-value>Ginzberg, Michael J.</displayed-value><stored-value>390344</stored-value></pair>
+      <pair><displayed-value>Giroud, Xavier</displayed-value><stored-value>850463</stored-value></pair>
+      <pair><displayed-value>Gittelman, Michelle</displayed-value><stored-value>349464</stored-value></pair>
+      <pair><displayed-value>Givoly, Dan</displayed-value><stored-value>16160</stored-value></pair>
+
+      <pair><displayed-value>Gode, Dan</displayed-value><stored-value>1131112</stored-value></pair>
+      <pair><displayed-value>Gode, Dhanajay K.</displayed-value><stored-value>1131114</stored-value></pair>
+      <pair><displayed-value>Gode, Dhananjay (Dan) K.</displayed-value><stored-value>19943</stored-value></pair>
+      <pair><displayed-value>Goetz, Charles John</displayed-value><stored-value>23218</stored-value></pair>
+      <pair><displayed-value>Goetzmann, William N.</displayed-value><stored-value>2309</stored-value></pair>
+      <pair><displayed-value>Goldberg, Linda S.</displayed-value><stored-value>50703</stored-value></pair>
+
+      <pair><displayed-value>Goldberg, Michael D.</displayed-value><stored-value>483755</stored-value></pair>
+      <pair><displayed-value>Goldberg, Stephen R.</displayed-value><stored-value>55570</stored-value></pair>
+      <pair><displayed-value>Golder, Peter N.</displayed-value><stored-value>634166</stored-value></pair>
+      <pair><displayed-value>Goldfarb, Avi</displayed-value><stored-value>333590</stored-value></pair>
+      <pair><displayed-value>Goldreich, David</displayed-value><stored-value>158371</stored-value></pair>
+      <pair><displayed-value>Goldsmith, Kelly</displayed-value><stored-value>765756</stored-value></pair>
+
+      <pair><displayed-value>Gonen, Ido</displayed-value><stored-value>1133329</stored-value></pair>
+      <pair><displayed-value>Gong, Gang</displayed-value><stored-value>281662</stored-value></pair>
+      <pair><displayed-value>Gonzalez-Eiras, Mart√ån</displayed-value><stored-value>250827</stored-value></pair>
+      <pair><displayed-value>Goolsbee, Austan</displayed-value><stored-value>131421</stored-value></pair>
+      <pair><displayed-value>Gopal, Ram D.</displayed-value><stored-value>370246</stored-value></pair>
+      <pair><displayed-value>Gopikrishnan, Parameswaran</displayed-value><stored-value>347406</stored-value></pair>
+
+      <pair><displayed-value>Gosden, John A.</displayed-value><stored-value>1143349</stored-value></pair>
+      <pair><displayed-value>Gottesman, Aron A.</displayed-value><stored-value>224305</stored-value></pair>
+      <pair><displayed-value>Govindaraj, Suresh</displayed-value><stored-value>20885</stored-value></pair>
+      <pair><displayed-value>Gowrisankaran, Gautam</displayed-value><stored-value>31587</stored-value></pair>
+      <pair><displayed-value>Goyenko, Ruslan</displayed-value><stored-value>352464</stored-value></pair>
+      <pair><displayed-value>Graham, John D.</displayed-value><stored-value>616897</stored-value></pair>
+
+      <pair><displayed-value>Grajek, Michal</displayed-value><stored-value>365888</stored-value></pair>
+      <pair><displayed-value>Gramm, Wendy</displayed-value><stored-value>711506</stored-value></pair>
+      <pair><displayed-value>Gravano, Luis</displayed-value><stored-value>1131957</stored-value></pair>
+      <pair><displayed-value>Green, Clifton</displayed-value><stored-value>756399</stored-value></pair>
+      <pair><displayed-value>Green, T. Clifton</displayed-value><stored-value>62092</stored-value></pair>
+      <pair><displayed-value>Greenberg, Edward</displayed-value><stored-value>44962</stored-value></pair>
+
+      <pair><displayed-value>Greene, William H.</displayed-value><stored-value>20759</stored-value></pair>
+      <pair><displayed-value>Greenleaf, Eric</displayed-value><stored-value>83827</stored-value></pair>
+      <pair><displayed-value>Greenstein, Shane M.</displayed-value><stored-value>31250</stored-value></pair>
+      <pair><displayed-value>Greenwood, Jeremy</displayed-value><stored-value>80708</stored-value></pair>
+      <pair><displayed-value>Greenwood, Robin Marc</displayed-value><stored-value>280104</stored-value></pair>
+      <pair><displayed-value>Grigoras, Elena</displayed-value><stored-value>1346484</stored-value></pair>
+
+      <pair><displayed-value>Grinblatt, Mark</displayed-value><stored-value>67458</stored-value></pair>
+      <pair><displayed-value>Grishchenko, Olesya V.</displayed-value><stored-value>327449</stored-value></pair>
+      <pair><displayed-value>Grody, Allan D.</displayed-value><stored-value>544794</stored-value></pair>
+      <pair><displayed-value>Gross, Pamela HB</displayed-value><stored-value>1143315</stored-value></pair>
+      <pair><displayed-value>Gruber, Marti J</displayed-value><stored-value>1148136</stored-value></pair>
+      <pair><displayed-value>Gruber, Martin J.</displayed-value><stored-value>20851</stored-value></pair>
+
+      <pair><displayed-value>Gruenfeld, Deborah H.</displayed-value><stored-value>327451</stored-value></pair>
+      <pair><displayed-value>Grzybowski, Lukasz</displayed-value><stored-value>435230</stored-value></pair>
+      <pair><displayed-value>Gu, Bin</displayed-value><stored-value>359302</stored-value></pair>
+      <pair><displayed-value>Gu, Feng</displayed-value><stored-value>62791</stored-value></pair>
+      <pair><displayed-value>Gudhus, Keith</displayed-value><stored-value>1133331</stored-value></pair>
+      <pair><displayed-value>Gul, Ferdinand A.</displayed-value><stored-value>62751</stored-value></pair>
+
+      <pair><displayed-value>Guner, Nezih</displayed-value><stored-value>213316</stored-value></pair>
+      <pair><displayed-value>Gunn, Ronald R.</displayed-value><stored-value>53367</stored-value></pair>
+      <pair><displayed-value>Guo, Hongtao</displayed-value><stored-value>112765</stored-value></pair>
+      <pair><displayed-value>Guo, Hui</displayed-value><stored-value>295148</stored-value></pair>
+      <pair><displayed-value>Guo, Re-Jin J.</displayed-value><stored-value>327185</stored-value></pair>
+      <pair><displayed-value>Gupta, Alok</displayed-value><stored-value>714384</stored-value></pair>
+
+      <pair><displayed-value>Gupta, Anurag</displayed-value><stored-value>136710</stored-value></pair>
+      <pair><displayed-value>Gurvich, Itay</displayed-value><stored-value>1138823</stored-value></pair>
+      <pair><displayed-value>Guthrie, Doug</displayed-value><stored-value>499370</stored-value></pair>
+      <pair><displayed-value>Guti√àrrez-Hita, Carlos</displayed-value><stored-value>887473</stored-value></pair>
+      <pair><displayed-value>G‚Äörleanu, Nicolae</displayed-value><stored-value>1056487</stored-value></pair>
+      <pair><displayed-value>Habib, Michel A.</displayed-value><stored-value>45126</stored-value></pair>
+
+      <pair><displayed-value>Hackel, Kenneth S.</displayed-value><stored-value>242330</stored-value></pair>
+      <pair><displayed-value>Hahn, Jinyong</displayed-value><stored-value>145354</stored-value></pair>
+      <pair><displayed-value>Hahn, Moritz</displayed-value><stored-value>1028581</stored-value></pair>
+      <pair><displayed-value>Hahn, Robert W.</displayed-value><stored-value>153589</stored-value></pair>
+      <pair><displayed-value>Hahs Flaharty, Linda J.</displayed-value><stored-value>143629</stored-value></pair>
+      <pair><displayed-value>Hait, David J.</displayed-value><stored-value>44098</stored-value></pair>
+
+      <pair><displayed-value>Haldeman, Robert</displayed-value><stored-value>136399</stored-value></pair>
+      <pair><displayed-value>Hall, Robert E.</displayed-value><stored-value>45944</stored-value></pair>
+      <pair><displayed-value>Hallman, Greg</displayed-value><stored-value>381712</stored-value></pair>
+      <pair><displayed-value>Halov, Nikolay</displayed-value><stored-value>352876</stored-value></pair>
+      <pair><displayed-value>Hamao, Yasushi</displayed-value><stored-value>22453</stored-value></pair>
+      <pair><displayed-value>Handa, Puneet</displayed-value><stored-value>23118</stored-value></pair>
+
+      <pair><displayed-value>Hann, Rebecca N.</displayed-value><stored-value>337331</stored-value></pair>
+      <pair><displayed-value>Hansen, Gary D.</displayed-value><stored-value>55738</stored-value></pair>
+      <pair><displayed-value>Harmantzis, Fotios</displayed-value><stored-value>389663</stored-value></pair>
+      <pair><displayed-value>Harris, Lawrence</displayed-value><stored-value>17344</stored-value></pair>
+      <pair><displayed-value>Hartzel, Jay C.</displayed-value><stored-value>1148483</stored-value></pair>
+      <pair><displayed-value>Hartzell, Jay C.</displayed-value><stored-value>223681</stored-value></pair>
+
+      <pair><displayed-value>Hasan, Iftekhar</displayed-value><stored-value>77268</stored-value></pair>
+      <pair><displayed-value>Hasbrouck, Joel</displayed-value><stored-value>1043</stored-value></pair>
+      <pair><displayed-value>Haselmann, Rainer F. H.</displayed-value><stored-value>452347</stored-value></pair>
+      <pair><displayed-value>Hauge, Janice A.</displayed-value><stored-value>744979</stored-value></pair>
+      <pair><displayed-value>Haugh, Martin</displayed-value><stored-value>327012</stored-value></pair>
+      <pair><displayed-value>Hauser, Shmuel</displayed-value><stored-value>42203</stored-value></pair>
+
+      <pair><displayed-value>Hausken, Kjell</displayed-value><stored-value>336843</stored-value></pair>
+      <pair><displayed-value>Hausman, Jerry A.</displayed-value><stored-value>21519</stored-value></pair>
+      <pair><displayed-value>Haw, In-Mu</displayed-value><stored-value>44524</stored-value></pair>
+      <pair><displayed-value>Hayn, Carla</displayed-value><stored-value>62876</stored-value></pair>
+      <pair><displayed-value>Hayt, Gregory S.</displayed-value><stored-value>145122</stored-value></pair>
+      <pair><displayed-value>Hazlett, Thomas W.</displayed-value><stored-value>75418</stored-value></pair>
+
+      <pair><displayed-value>He, Chuan</displayed-value><stored-value>116649</stored-value></pair>
+      <pair><displayed-value>Heathcote, Jonathan</displayed-value><stored-value>327775</stored-value></pair>
+      <pair><displayed-value>Hebert, William N.</displayed-value><stored-value>863273</stored-value></pair>
+      <pair><displayed-value>Heider, Florian</displayed-value><stored-value>276127</stored-value></pair>
+      <pair><displayed-value>Hellwig, Christian</displayed-value><stored-value>342765</stored-value></pair>
+      <pair><displayed-value>Hendel, Igal E.</displayed-value><stored-value>151768</stored-value></pair>
+
+      <pair><displayed-value>Hendry, David F.</displayed-value><stored-value>48860</stored-value></pair>
+      <pair><displayed-value>Henriksen, Espen R.</displayed-value><stored-value>286514</stored-value></pair>
+      <pair><displayed-value>Hens, Niel</displayed-value><stored-value>1147167</stored-value></pair>
+      <pair><displayed-value>Hervas-Drane, Andres</displayed-value><stored-value>701983</stored-value></pair>
+      <pair><displayed-value>Hess, James D.</displayed-value><stored-value>328083</stored-value></pair>
+      <pair><displayed-value>Hill, Shawndra</displayed-value><stored-value>636819</stored-value></pair>
+
+      <pair><displayed-value>Hiltz, Starr Roxanne</displayed-value><stored-value>1133791</stored-value></pair>
+      <pair><displayed-value>Himmelberg, Charles P.</displayed-value><stored-value>22459</stored-value></pair>
+      <pair><displayed-value>Hiraki, Takato</displayed-value><stored-value>67452</stored-value></pair>
+      <pair><displayed-value>Ho, T.S.</displayed-value><stored-value>1151903</stored-value></pair>
+      <pair><displayed-value>Ho, Teng-Suan</displayed-value><stored-value>1153787</stored-value></pair>
+      <pair><displayed-value>Hochberg, Yael V.</displayed-value><stored-value>349530</stored-value></pair>
+
+      <pair><displayed-value>Hogan, William W.</displayed-value><stored-value>99160</stored-value></pair>
+      <pair><displayed-value>Hollie, Dana</displayed-value><stored-value>353583</stored-value></pair>
+      <pair><displayed-value>Hollingsworth, Carl W.</displayed-value><stored-value>389362</stored-value></pair>
+      <pair><displayed-value>Hollingworth, Bruce</displayed-value><stored-value>1132671</stored-value></pair>
+      <pair><displayed-value>Holtz-Eakin, Douglas</displayed-value><stored-value>84888</stored-value></pair>
+      <pair><displayed-value>Hong, Harrison G.</displayed-value><stored-value>342554</stored-value></pair>
+
+      <pair><displayed-value>Hong, Seung Hyun</displayed-value><stored-value>105141</stored-value></pair>
+      <pair><displayed-value>Honhon, Dorothee</displayed-value><stored-value>332071</stored-value></pair>
+      <pair><displayed-value>Hopenhagn, Hugo</displayed-value><stored-value>1145829</stored-value></pair>
+      <pair><displayed-value>Hopenhayn, Hugo A.</displayed-value><stored-value>47588</stored-value></pair>
+      <pair><displayed-value>Hornstein, Abigail S.</displayed-value><stored-value>442067</stored-value></pair>
+      <pair><displayed-value>Horowitz, Tina</displayed-value><stored-value>10397</stored-value></pair>
+
+      <pair><displayed-value>Hortacsu, Ali</displayed-value><stored-value>229628</stored-value></pair>
+      <pair><displayed-value>Horv¬∑th, Lajos</displayed-value><stored-value>571921</stored-value></pair>
+      <pair><displayed-value>Houston, Joel F.</displayed-value><stored-value>16484</stored-value></pair>
+      <pair><displayed-value>Howell, Jamie</displayed-value><stored-value>1146526</stored-value></pair>
+      <pair><displayed-value>Hsieh, Mengchen</displayed-value><stored-value>582504</stored-value></pair>
+      <pair><displayed-value>Hu, Jiawei</displayed-value><stored-value>272833</stored-value></pair>
+
+      <pair><displayed-value>Hu, Jie</displayed-value><stored-value>1132255</stored-value></pair>
+      <pair><displayed-value>Hu, Wei-Min</displayed-value><stored-value>854256</stored-value></pair>
+      <pair><displayed-value>Huang, Jing-Zhi Jay</displayed-value><stored-value>739</stored-value></pair>
+      <pair><displayed-value>Huang, Jing-zhi</displayed-value><stored-value>1148423</stored-value></pair>
+      <pair><displayed-value>Huang, Ke-Wei</displayed-value><stored-value>555207</stored-value></pair>
+      <pair><displayed-value>Huang, Ming</displayed-value><stored-value>1437</stored-value></pair>
+
+      <pair><displayed-value>Huang, Rong</displayed-value><stored-value>346129</stored-value></pair>
+      <pair><displayed-value>Huberman, Bernardo A.</displayed-value><stored-value>2040</stored-value></pair>
+      <pair><displayed-value>Hughes, Alan</displayed-value><stored-value>178790</stored-value></pair>
+      <pair><displayed-value>Hukkawala, Naeem</displayed-value><stored-value>1150542</stored-value></pair>
+      <pair><displayed-value>Hull, John C.</displayed-value><stored-value>224834</stored-value></pair>
+      <pair><displayed-value>Hummel, Robert A.</displayed-value><stored-value>1135974</stored-value></pair>
+
+      <pair><displayed-value>Hunter, William Curt</displayed-value><stored-value>16301</stored-value></pair>
+      <pair><displayed-value>Hurkens, J.P.M. (Sjaak)</displayed-value><stored-value>54300</stored-value></pair>
+      <pair><displayed-value>Hurvich, C. M.</displayed-value><stored-value>1144330</stored-value></pair>
+      <pair><displayed-value>Hurvich, Califford M.</displayed-value><stored-value>1147614</stored-value></pair>
+      <pair><displayed-value>Hurvich, Clifford M.</displayed-value><stored-value>337443</stored-value></pair>
+      <pair><displayed-value>Hylleberg, Svend</displayed-value><stored-value>25363</stored-value></pair>
+
+      <pair><displayed-value>ICF, Yale</displayed-value><stored-value>223089</stored-value></pair>
+      <pair><displayed-value>Ibbotson, Roger G.</displayed-value><stored-value>2315</stored-value></pair>
+      <pair><displayed-value>Ibragimov, Rustam</displayed-value><stored-value>105146</stored-value></pair>
+      <pair><displayed-value>Idicula, John</displayed-value><stored-value>416207</stored-value></pair>
+      <pair><displayed-value>Igbaria, Magid</displayed-value><stored-value>1135980</stored-value></pair>
+      <pair><displayed-value>Inderst, Roman</displayed-value><stored-value>190751</stored-value></pair>
+
+      <pair><displayed-value>Institute, CFA</displayed-value><stored-value>362492</stored-value></pair>
+      <pair><displayed-value>Ioannidis, Sotiris</displayed-value><stored-value>701845</stored-value></pair>
+      <pair><displayed-value>Ipeirotis, Panagiotis G.</displayed-value><stored-value>586795</stored-value></pair>
+      <pair><displayed-value>Ireland, Chris</displayed-value><stored-value>1133328</stored-value></pair>
+      <pair><displayed-value>Isakowitz, Tomas</displayed-value><stored-value>1133776</stored-value></pair>
+      <pair><displayed-value>Ivashina, Victoria</displayed-value><stored-value>380705</stored-value></pair>
+
+      <pair><displayed-value>Ives, Blake</displayed-value><stored-value>1143421</stored-value></pair>
+      <pair><displayed-value>Iyengar, Raghuram</displayed-value><stored-value>994217</stored-value></pair>
+      <pair><displayed-value>Iyer, Ganesh</displayed-value><stored-value>328057</stored-value></pair>
+      <pair><displayed-value>J. White, Lawrence</displayed-value><stored-value>1132674</stored-value></pair>
+      <pair><displayed-value>Jackson, Susan</displayed-value><stored-value>80268</stored-value></pair>
+      <pair><displayed-value>Jacob, Boudoukh</displayed-value><stored-value>1151305</stored-value></pair>
+
+      <pair><displayed-value>Jacoby, Jacob</displayed-value><stored-value>231377</stored-value></pair>
+      <pair><displayed-value>Jain, Alpa</displayed-value><stored-value>1131965</stored-value></pair>
+      <pair><displayed-value>Jain, Shailendra Pratap</displayed-value><stored-value>19972</stored-value></pair>
+      <pair><displayed-value>James, Paula</displayed-value><stored-value>1146524</stored-value></pair>
+      <pair><displayed-value>Jamison, Mark A.</displayed-value><stored-value>415921</stored-value></pair>
+      <pair><displayed-value>Janiszewski, Chris</displayed-value><stored-value>381831</stored-value></pair>
+
+      <pair><displayed-value>Jankowitsch, Rainer</displayed-value><stored-value>327328</stored-value></pair>
+      <pair><displayed-value>Jarke, Matthias</displayed-value><stored-value>1142951</stored-value></pair>
+      <pair><displayed-value>Jeanblanc, Monique</displayed-value><stored-value>114711</stored-value></pair>
+      <pair><displayed-value>Jegadeesh, Narasimhan</displayed-value><stored-value>16600</stored-value></pair>
+      <pair><displayed-value>Jelassi, M. Tawfik</displayed-value><stored-value>1142080</stored-value></pair>
+      <pair><displayed-value>Jenkinson, Tim</displayed-value><stored-value>33679</stored-value></pair>
+
+      <pair><displayed-value>Jennings, Robert H.</displayed-value><stored-value>32971</stored-value></pair>
+      <pair><displayed-value>Jensen, Christian S.</displayed-value><stored-value>1137345</stored-value></pair>
+      <pair><displayed-value>Jeon, Doh-Shin</displayed-value><stored-value>332574</stored-value></pair>
+      <pair><displayed-value>Jesper Christensen, Bent</displayed-value><stored-value>1153781</stored-value></pair>
+      <pair><displayed-value>Jewitt, Ian D.</displayed-value><stored-value>81716</stored-value></pair>
+      <pair><displayed-value>Jha, Shubin</displayed-value><stored-value>1148471</stored-value></pair>
+
+      <pair><displayed-value>Jiang, Guolin</displayed-value><stored-value>400614</stored-value></pair>
+      <pair><displayed-value>Jiang, Tianyi</displayed-value><stored-value>877455</stored-value></pair>
+      <pair><displayed-value>Jing, Bing</displayed-value><stored-value>418497</stored-value></pair>
+      <pair><displayed-value>Johar, Hardeep</displayed-value><stored-value>1141331</stored-value></pair>
+      <pair><displayed-value>Johari, Ramesh</displayed-value><stored-value>661668</stored-value></pair>
+      <pair><displayed-value>John, Klose</displayed-value><stored-value>1151906</stored-value></pair>
+
+      <pair><displayed-value>John, Kose</displayed-value><stored-value>20854</stored-value></pair>
+      <pair><displayed-value>John C., Driscoll</displayed-value><stored-value>1147162</stored-value></pair>
+      <pair><displayed-value>Johnson, Kerri</displayed-value><stored-value>713458</stored-value></pair>
+      <pair><displayed-value>Jones, Christopher</displayed-value><stored-value>1142303</stored-value></pair>
+      <pair><displayed-value>Jorde, Thomas M.</displayed-value><stored-value>100249</stored-value></pair>
+      <pair><displayed-value>Jorgensen, Bjorn N.</displayed-value><stored-value>62431</stored-value></pair>
+
+      <pair><displayed-value>Joshi, Yogesh V.</displayed-value><stored-value>352270</stored-value></pair>
+      <pair><displayed-value>Joskow, Paul L.</displayed-value><stored-value>21525</stored-value></pair>
+      <pair><displayed-value>Jouini, Elyes</displayed-value><stored-value>259541</stored-value></pair>
+      <pair><displayed-value>Jovanovic, Boyan</displayed-value><stored-value>63276</stored-value></pair>
+      <pair><displayed-value>Ju, Nengjiu</displayed-value><stored-value>363</stored-value></pair>
+      <pair><displayed-value>Jurgens, Amber</displayed-value><stored-value>714395</stored-value></pair>
+
+      <pair><displayed-value>Kacperczyk, Marcin T.</displayed-value><stored-value>301912</stored-value></pair>
+      <pair><displayed-value>Kadam, Ashay</displayed-value><stored-value>336363</stored-value></pair>
+      <pair><displayed-value>Kahan, Marcel</displayed-value><stored-value>17626</stored-value></pair>
+      <pair><displayed-value>Kahn, Alfred E.</displayed-value><stored-value>81458</stored-value></pair>
+      <pair><displayed-value>Kallal, Hedi</displayed-value><stored-value>71825</stored-value></pair>
+      <pair><displayed-value>Kallal, H√àdi</displayed-value><stored-value>1151307</stored-value></pair>
+
+      <pair><displayed-value>Kallberg, Jarl G. (Jerry)</displayed-value><stored-value>20858</stored-value></pair>
+      <pair><displayed-value>Kalt, Joseph P.</displayed-value><stored-value>242970</stored-value></pair>
+      <pair><displayed-value>Kambhu, John</displayed-value><stored-value>99021</stored-value></pair>
+      <pair><displayed-value>Kambil, Ajit</displayed-value><stored-value>1133783</stored-value></pair>
+      <pair><displayed-value>Kamis, Arnold</displayed-value><stored-value>419898</stored-value></pair>
+      <pair><displayed-value>Kaniel, Ron</displayed-value><stored-value>48389</stored-value></pair>
+
+      <pair><displayed-value>Kant, Tushar</displayed-value><stored-value>1334984</stored-value></pair>
+      <pair><displayed-value>Kaplan, Edward H.</displayed-value><stored-value>281819</stored-value></pair>
+      <pair><displayed-value>Karamti, Chiraz</displayed-value><stored-value>883410</stored-value></pair>
+      <pair><displayed-value>Karasek, Robert A., Jr.</displayed-value><stored-value>1143338</stored-value></pair>
+      <pair><displayed-value>Karlin, Brenda</displayed-value><stored-value>1334983</stored-value></pair>
+      <pair><displayed-value>Katsamakas, Evangelos</displayed-value><stored-value>412514</stored-value></pair>
+
+      <pair><displayed-value>Katz, Barbara G.</displayed-value><stored-value>17629</stored-value></pair>
+      <pair><displayed-value>Kauffman, Rob</displayed-value><stored-value>470142</stored-value></pair>
+      <pair><displayed-value>Kauffman, Robert J.</displayed-value><stored-value>920013</stored-value></pair>
+      <pair><displayed-value>Kauffman, Robert</displayed-value><stored-value>1142289</stored-value></pair>
+      <pair><displayed-value>Kaul, Aditya</displayed-value><stored-value>107869</stored-value></pair>
+      <pair><displayed-value>Kaushik, P.D.</displayed-value><stored-value>339448</stored-value></pair>
+
+      <pair><displayed-value>Kavajecz, Kenneth A.</displayed-value><stored-value>31959</stored-value></pair>
+      <pair><displayed-value>Keane, Michael P.</displayed-value><stored-value>31618</stored-value></pair>
+      <pair><displayed-value>Kedem, Zvi M.</displayed-value><stored-value>547044</stored-value></pair>
+      <pair><displayed-value>Kedia, Semi</displayed-value><stored-value>1148131</stored-value></pair>
+      <pair><displayed-value>Kedia, Simi</displayed-value><stored-value>66529</stored-value></pair>
+      <pair><displayed-value>Kehoe, Conor</displayed-value><stored-value>977184</stored-value></pair>
+
+      <pair><displayed-value>Keisler, H. Jerome</displayed-value><stored-value>265268</stored-value></pair>
+      <pair><displayed-value>Kelly, Bryan T.</displayed-value><stored-value>759326</stored-value></pair>
+      <pair><displayed-value>Kemerer, Chris F.</displayed-value><stored-value>409699</stored-value></pair>
+      <pair><displayed-value>Kendall, Jake</displayed-value><stored-value>409729</stored-value></pair>
+      <pair><displayed-value>Kesavan, Saravanan</displayed-value><stored-value>482582</stored-value></pair>
+      <pair><displayed-value>Kilian, Lutz</displayed-value><stored-value>50236</stored-value></pair>
+
+      <pair><displayed-value>Kim, Byung-Cheol</displayed-value><stored-value>841716</stored-value></pair>
+      <pair><displayed-value>Kim, Chansog Francis</displayed-value><stored-value>223537</stored-value></pair>
+      <pair><displayed-value>Kim, Dong Won</displayed-value><stored-value>104390</stored-value></pair>
+      <pair><displayed-value>Kim, Dongcheol</displayed-value><stored-value>17898</stored-value></pair>
+      <pair><displayed-value>Kim, Haeng Ran</displayed-value><stored-value>426792</stored-value></pair>
+      <pair><displayed-value>Kim, Harold Y.</displayed-value><stored-value>120188</stored-value></pair>
+
+      <pair><displayed-value>Kim, Jiyoung</displayed-value><stored-value>701994</stored-value></pair>
+      <pair><displayed-value>Kim, Myungsun</displayed-value><stored-value>395795</stored-value></pair>
+      <pair><displayed-value>Kim, Sung K.</displayed-value><stored-value>1143442</stored-value></pair>
+      <pair><displayed-value>Kim, Yongbeom</displayed-value><stored-value>1133780</stored-value></pair>
+      <pair><displayed-value>Kimbrough, Steven O.</displayed-value><stored-value>453197</stored-value></pair>
+      <pair><displayed-value>Kind, Axel H.</displayed-value><stored-value>276535</stored-value></pair>
+
+      <pair><displayed-value>Kirsh, Amir</displayed-value><stored-value>295189</stored-value></pair>
+      <pair><displayed-value>Kishore, Vellore</displayed-value><stored-value>136208</stored-value></pair>
+      <pair><displayed-value>Klapper, Leora F.</displayed-value><stored-value>1963</stored-value></pair>
+      <pair><displayed-value>Klein, April</displayed-value><stored-value>17575</stored-value></pair>
+      <pair><displayed-value>Kleindorfer, Paul R.</displayed-value><stored-value>124201</stored-value></pair>
+      <pair><displayed-value>Klimenko, Mikhail M.</displayed-value><stored-value>141241</stored-value></pair>
+
+      <pair><displayed-value>Knittel, Christopher R.</displayed-value><stored-value>200291</stored-value></pair>
+      <pair><displayed-value>Knopf, John D.</displayed-value><stored-value>912772</stored-value></pair>
+      <pair><displayed-value>Koch, Juergen</displayed-value><stored-value>1143343</stored-value></pair>
+      <pair><displayed-value>Koch, Jurgen</displayed-value><stored-value>1143320</stored-value></pair>
+      <pair><displayed-value>Koehl, Pierre-F.</displayed-value><stored-value>1151911</stored-value></pair>
+      <pair><displayed-value>Koijen, Ralph S. J.</displayed-value><stored-value>374406</stored-value></pair>
+
+      <pair><displayed-value>Konings, Jozef</displayed-value><stored-value>87410</stored-value></pair>
+      <pair><displayed-value>Konsynski, Benn</displayed-value><stored-value>349223</stored-value></pair>
+      <pair><displayed-value>Koopman, Siem Jan</displayed-value><stored-value>137911</stored-value></pair>
+      <pair><displayed-value>Kornhauser, Lewis A.</displayed-value><stored-value>119221</stored-value></pair>
+      <pair><displayed-value>Kotha, Suresh</displayed-value><stored-value>17633</stored-value></pair>
+      <pair><displayed-value>Kothari, S.P.</displayed-value><stored-value>17425</stored-value></pair>
+
+      <pair><displayed-value>Koticha, Apoorva</displayed-value><stored-value>15977</stored-value></pair>
+      <pair><displayed-value>Kotlikoff, Laurence J.</displayed-value><stored-value>44751</stored-value></pair>
+      <pair><displayed-value>Koufaris, Marios</displayed-value><stored-value>447162</stored-value></pair>
+      <pair><displayed-value>Krainer, John</displayed-value><stored-value>295386</stored-value></pair>
+      <pair><displayed-value>Krause, Jurgen</displayed-value><stored-value>1143319</stored-value></pair>
+      <pair><displayed-value>Krauss, Lindsay</displayed-value><stored-value>844278</stored-value></pair>
+
+      <pair><displayed-value>Krauss, Nicolas A.</displayed-value><stored-value>568148</stored-value></pair>
+      <pair><displayed-value>Kraussa, Nicolas</displayed-value><stored-value>1155487</stored-value></pair>
+      <pair><displayed-value>Kraut, Robert E.</displayed-value><stored-value>332747</stored-value></pair>
+      <pair><displayed-value>Krcmar, Helmut</displayed-value><stored-value>1142966</stored-value></pair>
+      <pair><displayed-value>Kremer, Ilan</displayed-value><stored-value>302954</stored-value></pair>
+      <pair><displayed-value>Kretschmer, Tobias</displayed-value><stored-value>350496</stored-value></pair>
+
+      <pair><displayed-value>Kreuger, Dirk</displayed-value><stored-value>1146525</stored-value></pair>
+      <pair><displayed-value>Kriebel, Charles H.</displayed-value><stored-value>370977</stored-value></pair>
+      <pair><displayed-value>Krinsky, Itzhak</displayed-value><stored-value>161621</stored-value></pair>
+      <pair><displayed-value>Krishnamurthy, Arvind</displayed-value><stored-value>141171</stored-value></pair>
+      <pair><displayed-value>Krishnan, Ramayya</displayed-value><stored-value>269035</stored-value></pair>
+      <pair><displayed-value>Krolzig, Martin</displayed-value><stored-value>1151303</stored-value></pair>
+
+      <pair><displayed-value>Krueger, Dirk</displayed-value><stored-value>92354</stored-value></pair>
+      <pair><displayed-value>Kruger, Justin</displayed-value><stored-value>712076</stored-value></pair>
+      <pair><displayed-value>Krugman, Paul R.</displayed-value><stored-value>21531</stored-value></pair>
+      <pair><displayed-value>Kumar, Akhi</displayed-value><stored-value>1133975</stored-value></pair>
+      <pair><displayed-value>Kumar, Alok</displayed-value><stored-value>56396</stored-value></pair>
+      <pair><displayed-value>Kumar, Alok</displayed-value><stored-value>1153497</stored-value></pair>
+
+      <pair><displayed-value>Kumar, Rachna</displayed-value><stored-value>1141328</stored-value></pair>
+      <pair><displayed-value>Kumar, V.</displayed-value><stored-value>994221</stored-value></pair>
+      <pair><displayed-value>Kumaraswamy, A.</displayed-value><stored-value>1142083</stored-value></pair>
+      <pair><displayed-value>Kumaraswamy, Arun</displayed-value><stored-value>678570</stored-value></pair>
+      <pair><displayed-value>Kumbhakar, Subal C.</displayed-value><stored-value>185128</stored-value></pair>
+      <pair><displayed-value>Kuper, Gabriel M.</displayed-value><stored-value>1141336</stored-value></pair>
+
+      <pair><displayed-value>Kwoka Jr., John E.</displayed-value><stored-value>1146531</stored-value></pair>
+      <pair><displayed-value>L. Silber, William</displayed-value><stored-value>1147622</stored-value></pair>
+      <pair><displayed-value>L. Silber*, William</displayed-value><stored-value>1147161</stored-value></pair>
+      <pair><displayed-value>LEE-WINGATE, SOOYEON NIKKI</displayed-value><stored-value>712095</stored-value></pair>
+      <pair><displayed-value>LaBarbera, Priscilla A.</displayed-value><stored-value>1143355</stored-value></pair>
+      <pair><displayed-value>LaBarbera, Priscilla Ann</displayed-value><stored-value>1141320</stored-value></pair>
+
+      <pair><displayed-value>Labys, Paul</displayed-value><stored-value>151739</stored-value></pair>
+      <pair><displayed-value>Lagos, Ricardo</displayed-value><stored-value>247872</stored-value></pair>
+      <pair><displayed-value>Laibson, David I.</displayed-value><stored-value>20341</stored-value></pair>
+      <pair><displayed-value>Lajbcygier, Paul</displayed-value><stored-value>809452</stored-value></pair>
+      <pair><displayed-value>Lakner, Peter</displayed-value><stored-value>336364</stored-value></pair>
+      <pair><displayed-value>Lally, Laura</displayed-value><stored-value>1135982</stored-value></pair>
+
+      <pair><displayed-value>Lambert-Mogiliansky, Ariane</displayed-value><stored-value>1131956</stored-value></pair>
+      <pair><displayed-value>Lambrecht, Anja</displayed-value><stored-value>617552</stored-value></pair>
+      <pair><displayed-value>Landier, Augustin</displayed-value><stored-value>262766</stored-value></pair>
+      <pair><displayed-value>Landskroner, Yoram</displayed-value><stored-value>94361</stored-value></pair>
+      <pair><displayed-value>Lang, Gabriel</displayed-value><stored-value>1147615</stored-value></pair>
+      <pair><displayed-value>Langberg, Nisan</displayed-value><stored-value>118208</stored-value></pair>
+
+      <pair><displayed-value>Lange, Jeffrey</displayed-value><stored-value>239017</stored-value></pair>
+      <pair><displayed-value>Lange, Joe</displayed-value><stored-value>58279</stored-value></pair>
+      <pair><displayed-value>Laudon, Kenneth</displayed-value><stored-value>1133784</stored-value></pair>
+      <pair><displayed-value>Lauterbach, Beni</displayed-value><stored-value>54391</stored-value></pair>
+      <pair><displayed-value>Lave, Lester B.</displayed-value><stored-value>259026</stored-value></pair>
+      <pair><displayed-value>Lazer, Ron</displayed-value><stored-value>276745</stored-value></pair>
+
+      <pair><displayed-value>Le, Anh</displayed-value><stored-value>568157</stored-value></pair>
+      <pair><displayed-value>LeBaron, Blake D.</displayed-value><stored-value>1108</stored-value></pair>
+      <pair><displayed-value>Leaver, Clare</displayed-value><stored-value>637144</stored-value></pair>
+      <pair><displayed-value>Lederman, Mara</displayed-value><stored-value>547010</stored-value></pair>
+      <pair><displayed-value>Lee, Cassia</displayed-value><stored-value>658905</stored-value></pair>
+      <pair><displayed-value>Lee, Chi-Wen Jevons</displayed-value><stored-value>1152397</stored-value></pair>
+
+      <pair><displayed-value>Lee, Gary G.J.</displayed-value><stored-value>143908</stored-value></pair>
+      <pair><displayed-value>Lee, Jae B.</displayed-value><stored-value>1143451</stored-value></pair>
+      <pair><displayed-value>Lee, Jeho</displayed-value><stored-value>473212</stored-value></pair>
+      <pair><displayed-value>Lee, Kyung-seol</displayed-value><stored-value>342729</stored-value></pair>
+      <pair><displayed-value>Lee, Robin S.</displayed-value><stored-value>858572</stored-value></pair>
+      <pair><displayed-value>Lehr, William</displayed-value><stored-value>1147509</stored-value></pair>
+
+      <pair><displayed-value>Lerman, Alina</displayed-value><stored-value>779914</stored-value></pair>
+      <pair><displayed-value>Lertwachara, Kaveepan</displayed-value><stored-value>370248</stored-value></pair>
+      <pair><displayed-value>Leshno, Moshe</displayed-value><stored-value>1141333</stored-value></pair>
+      <pair><displayed-value>Lesmond, David A.</displayed-value><stored-value>185491</stored-value></pair>
+      <pair><displayed-value>Lettau, Martin</displayed-value><stored-value>58454</stored-value></pair>
+      <pair><displayed-value>Lev, Baruch Itamar</displayed-value><stored-value>20898</stored-value></pair>
+
+      <pair><displayed-value>Levecq, Hugues</displayed-value><stored-value>28211</stored-value></pair>
+      <pair><displayed-value>Levich, Richard M.</displayed-value><stored-value>20862</stored-value></pair>
+      <pair><displayed-value>Levina, Natalia</displayed-value><stored-value>327560</stored-value></pair>
+      <pair><displayed-value>Levinthal, Daniel A.</displayed-value><stored-value>266292</stored-value></pair>
+      <pair><displayed-value>Levy, Amnon</displayed-value><stored-value>17635</stored-value></pair>
+      <pair><displayed-value>Levy, Amnon</displayed-value><stored-value>383436</stored-value></pair>
+
+      <pair><displayed-value>Levy, Nino</displayed-value><stored-value>365032</stored-value></pair>
+      <pair><displayed-value>Lewis, Barry L.</displayed-value><stored-value>217991</stored-value></pair>
+      <pair><displayed-value>Lewis, Melissa Fay</displayed-value><stored-value>393822</stored-value></pair>
+      <pair><displayed-value>Li, Bob</displayed-value><stored-value>653614</stored-value></pair>
+      <pair><displayed-value>Li, Kai NMI3</displayed-value><stored-value>328664</stored-value></pair>
+      <pair><displayed-value>Li, Kefei</displayed-value><stored-value>337442</stored-value></pair>
+
+      <pair><displayed-value>Li, Lexin</displayed-value><stored-value>1147164</stored-value></pair>
+      <pair><displayed-value>Li, Li NMI2</displayed-value><stored-value>145986</stored-value></pair>
+      <pair><displayed-value>Li, Siyi</displayed-value><stored-value>361943</stored-value></pair>
+      <pair><displayed-value>Liang, Bing</displayed-value><stored-value>1069</stored-value></pair>
+      <pair><displayed-value>Liang, Weijian</displayed-value><stored-value>686631</stored-value></pair>
+      <pair><displayed-value>Lianos, Ioannis</displayed-value><stored-value>565608</stored-value></pair>
+
+      <pair><displayed-value>Liao, Elena</displayed-value><stored-value>428974</stored-value></pair>
+      <pair><displayed-value>Liao, Hsien-Hsing</displayed-value><stored-value>491810</stored-value></pair>
+      <pair><displayed-value>Lichtman, Douglas Gary</displayed-value><stored-value>130905</stored-value></pair>
+      <pair><displayed-value>Lilien, Steven</displayed-value><stored-value>1131108</stored-value></pair>
+      <pair><displayed-value>Lilien, Steven B.</displayed-value><stored-value>62452</stored-value></pair>
+      <pair><displayed-value>Liljenquist, Katie</displayed-value><stored-value>118215</stored-value></pair>
+
+      <pair><displayed-value>Lin, Valdimir Ya.</displayed-value><stored-value>1141334</stored-value></pair>
+      <pair><displayed-value>Lindahl, Frederick W.</displayed-value><stored-value>16626</stored-value></pair>
+      <pair><displayed-value>Linder, Diane C.</displayed-value><stored-value>358088</stored-value></pair>
+      <pair><displayed-value>Lindner, Ines</displayed-value><stored-value>486858</stored-value></pair>
+      <pair><displayed-value>Linnemann, Volker</displayed-value><stored-value>1143310</stored-value></pair>
+      <pair><displayed-value>Litan, Robert E.</displayed-value><stored-value>179991</stored-value></pair>
+
+      <pair><displayed-value>Litov, Lubomir P.</displayed-value><stored-value>327450</stored-value></pair>
+      <pair><displayed-value>Littman, Michael L.</displayed-value><stored-value>1133778</stored-value></pair>
+      <pair><displayed-value>Liu, Bing</displayed-value><stored-value>1132254</stored-value></pair>
+      <pair><displayed-value>Liu, Charles Z.</displayed-value><stored-value>713292</stored-value></pair>
+      <pair><displayed-value>Liu, Chi-Chun</displayed-value><stored-value>534381</stored-value></pair>
+      <pair><displayed-value>Liu, Crocker H.</displayed-value><stored-value>20864</stored-value></pair>
+
+      <pair><displayed-value>Liu, Debin</displayed-value><stored-value>701914</stored-value></pair>
+      <pair><displayed-value>Liu, Qihong</displayed-value><stored-value>398784</stored-value></pair>
+      <pair><displayed-value>Livnat, Joshua</displayed-value><stored-value>20900</stored-value></pair>
+      <pair><displayed-value>Lizzeri, Alessandro</displayed-value><stored-value>150888</stored-value></pair>
+      <pair><displayed-value>Ljungqvist, Alexander</displayed-value><stored-value>33683</stored-value></pair>
+      <pair><displayed-value>Llorente, Guillermo</displayed-value><stored-value>1149011</stored-value></pair>
+
+      <pair><displayed-value>Lobel, Ilan</displayed-value><stored-value>1033603</stored-value></pair>
+      <pair><displayed-value>Lochovsky, F.H.</displayed-value><stored-value>1143347</stored-value></pair>
+      <pair><displayed-value>Lochstoer, Lars A.</displayed-value><stored-value>337715</stored-value></pair>
+      <pair><displayed-value>Longawa, Vicky M.</displayed-value><stored-value>362396</stored-value></pair>
+      <pair><displayed-value>Lookabaugh, Tom</displayed-value><stored-value>417769</stored-value></pair>
+      <pair><displayed-value>Lopomo, Giuseppe</displayed-value><stored-value>20777</stored-value></pair>
+
+      <pair><displayed-value>Lorsch, Jay W.</displayed-value><stored-value>38965</stored-value></pair>
+      <pair><displayed-value>Lothian, James R.</displayed-value><stored-value>83594</stored-value></pair>
+      <pair><displayed-value>Lovell, C.A. Knox</displayed-value><stored-value>240400</stored-value></pair>
+      <pair><displayed-value>Lozano, Ana</displayed-value><stored-value>1152958</stored-value></pair>
+      <pair><displayed-value>Lozano-Vivas, Ana</displayed-value><stored-value>1152952</stored-value></pair>
+      <pair><displayed-value>Lu, Yang</displayed-value><stored-value>1148867</stored-value></pair>
+
+      <pair><displayed-value>Lu, Yi NMI1</displayed-value><stored-value>361957</stored-value></pair>
+      <pair><displayed-value>Lucas, Andr√à</displayed-value><stored-value>1151296</stored-value></pair>
+      <pair><displayed-value>Lucas, Henry C.</displayed-value><stored-value>415752</stored-value></pair>
+      <pair><displayed-value>Lucas, Henry Jr.</displayed-value><stored-value>1135981</stored-value></pair>
+      <pair><displayed-value>Lucas Jr., Henry C.</displayed-value><stored-value>1137351</stored-value></pair>
+      <pair><displayed-value>Ludvigson, Sydney C.</displayed-value><stored-value>66250</stored-value></pair>
+
+      <pair><displayed-value>Lunde, Asger</displayed-value><stored-value>25449</stored-value></pair>
+      <pair><displayed-value>Lurie, Nicholas H.</displayed-value><stored-value>421541</stored-value></pair>
+      <pair><displayed-value>Lustig, Hanno N.</displayed-value><stored-value>295977</stored-value></pair>
+      <pair><displayed-value>Lutter, Randall</displayed-value><stored-value>237989</stored-value></pair>
+      <pair><displayed-value>Lynch, Anthony W.</displayed-value><stored-value>20866</stored-value></pair>
+      <pair><displayed-value>Lynch, Eileen M.</displayed-value><stored-value>1143348</stored-value></pair>
+
+      <pair><displayed-value>Lynn, Stephen</displayed-value><stored-value>115001</stored-value></pair>
+      <pair><displayed-value>Lys, Thomas Z.</displayed-value><stored-value>23037</stored-value></pair>
+      <pair><displayed-value>Lyytinen, Kalle J.</displayed-value><stored-value>583866</stored-value></pair>
+      <pair><displayed-value>M. Gallo, Giampiero</displayed-value><stored-value>1147620</stored-value></pair>
+      <pair><displayed-value>M. Levich, Richard</displayed-value><stored-value>1147611</stored-value></pair>
+      <pair><displayed-value>M. Mueller, Holger</displayed-value><stored-value>1147610</stored-value></pair>
+
+      <pair><displayed-value>MA, Pai-chun</displayed-value><stored-value>1142963</stored-value></pair>
+      <pair><displayed-value>MacAvoy, Paul W.</displayed-value><stored-value>63054</stored-value></pair>
+      <pair><displayed-value>MacDonald, Glenn M.</displayed-value><stored-value>20012</stored-value></pair>
+      <pair><displayed-value>MacLeod, W. Bentley</displayed-value><stored-value>832328</stored-value></pair>
+      <pair><displayed-value>Macdonald, Ben</displayed-value><stored-value>1133325</stored-value></pair>
+      <pair><displayed-value>Macskassy, Sofus</displayed-value><stored-value>660162</stored-value></pair>
+
+      <pair><displayed-value>Madhavan, Ananth</displayed-value><stored-value>17360</stored-value></pair>
+      <pair><displayed-value>Madhavan, R.</displayed-value><stored-value>1142069</stored-value></pair>
+      <pair><displayed-value>Madhavan, Raghav K.</displayed-value><stored-value>1142072</stored-value></pair>
+      <pair><displayed-value>Magee, Joseph Carl</displayed-value><stored-value>341625</stored-value></pair>
+      <pair><displayed-value>Maggi, Giovanni</displayed-value><stored-value>74188</stored-value></pair>
+      <pair><displayed-value>Mahajan, Shalini</displayed-value><stored-value>1133334</stored-value></pair>
+
+      <pair><displayed-value>Mahanti, Sriketan</displayed-value><stored-value>457236</stored-value></pair>
+      <pair><displayed-value>Mahanti, Sriketan</displayed-value><stored-value>854186</stored-value></pair>
+      <pair><displayed-value>Maheswaran, Durairaj</displayed-value><stored-value>79840</stored-value></pair>
+      <pair><displayed-value>Mahoney, Paul G.</displayed-value><stored-value>44562</stored-value></pair>
+      <pair><displayed-value>Maindiratta, Ajay</displayed-value><stored-value>20902</stored-value></pair>
+      <pair><displayed-value>Maitland, Carleen</displayed-value><stored-value>395832</stored-value></pair>
+
+      <pair><displayed-value>Maitra, Pushkar</displayed-value><stored-value>52487</stored-value></pair>
+      <pair><displayed-value>Majumdar, Makul</displayed-value><stored-value>1133348</stored-value></pair>
+      <pair><displayed-value>Majumdar, Mukul</displayed-value><stored-value>81460</stored-value></pair>
+      <pair><displayed-value>Malik, Gaurav</displayed-value><stored-value>1148138</stored-value></pair>
+      <pair><displayed-value>Malkiel, Burton G.</displayed-value><stored-value>17846</stored-value></pair>
+      <pair><displayed-value>Mallik, Gaurav</displayed-value><stored-value>457254</stored-value></pair>
+
+      <pair><displayed-value>Malloy, Christopher J.</displayed-value><stored-value>97668</stored-value></pair>
+      <pair><displayed-value>Malone, Rich</displayed-value><stored-value>1142071</stored-value></pair>
+      <pair><displayed-value>Man-Cho So, Anthony</displayed-value><stored-value>1147155</stored-value></pair>
+      <pair><displayed-value>Mancini, Cecilia</displayed-value><stored-value>649903</stored-value></pair>
+      <pair><displayed-value>Mancini, Loriano</displayed-value><stored-value>345154</stored-value></pair>
+      <pair><displayed-value>Mandelbaum, Avishai</displayed-value><stored-value>1143353</stored-value></pair>
+
+      <pair><displayed-value>Manganelli, Simone</displayed-value><stored-value>196912</stored-value></pair>
+      <pair><displayed-value>Mann, Christopher</displayed-value><stored-value>516501</stored-value></pair>
+      <pair><displayed-value>Mann, Christopher</displayed-value><stored-value>1148838</stored-value></pair>
+      <pair><displayed-value>Manso, Gustavo</displayed-value><stored-value>348878</stored-value></pair>
+      <pair><displayed-value>Mantena, Ravi</displayed-value><stored-value>380045</stored-value></pair>
+      <pair><displayed-value>Marcus, Alan J.</displayed-value><stored-value>25781</stored-value></pair>
+
+      <pair><displayed-value>Marimon, Ramon</displayed-value><stored-value>30662</stored-value></pair>
+      <pair><displayed-value>Marin, Dalia</displayed-value><stored-value>48052</stored-value></pair>
+      <pair><displayed-value>Marisetty, Vijaya B.</displayed-value><stored-value>328926</stored-value></pair>
+      <pair><displayed-value>Mark, Gideon</displayed-value><stored-value>560800</stored-value></pair>
+      <pair><displayed-value>Mark, Robert M.</displayed-value><stored-value>1137369</stored-value></pair>
+      <pair><displayed-value>Markus, M. Lynne</displayed-value><stored-value>1135968</stored-value></pair>
+
+      <pair><displayed-value>Marquardt, Carol</displayed-value><stored-value>47028</stored-value></pair>
+      <pair><displayed-value>Marr, Kenneth</displayed-value><stored-value>1142078</stored-value></pair>
+      <pair><displayed-value>Marr, Kenneth L.</displayed-value><stored-value>1135959</stored-value></pair>
+      <pair><displayed-value>Marsden, James R.</displayed-value><stored-value>370247</stored-value></pair>
+      <pair><displayed-value>Marston, Felicia C.</displayed-value><stored-value>252672</stored-value></pair>
+      <pair><displayed-value>Marti, Subrahmanyam</displayed-value><stored-value>1147165</stored-value></pair>
+
+      <pair><displayed-value>Martinez-Jerez, Francisco de Asis</displayed-value><stored-value>79593</stored-value></pair>
+      <pair><displayed-value>Martins, Luis L.</displayed-value><stored-value>1137354</stored-value></pair>
+      <pair><displayed-value>Mashruwala, Raj</displayed-value><stored-value>365910</stored-value></pair>
+      <pair><displayed-value>Masset, Pierre</displayed-value><stored-value>1150541</stored-value></pair>
+      <pair><displayed-value>Massoud, Nadia</displayed-value><stored-value>110449</stored-value></pair>
+      <pair><displayed-value>Massoud, Nadia Ziad</displayed-value><stored-value>1151901</stored-value></pair>
+
+      <pair><displayed-value>Mathiassen, Lars</displayed-value><stored-value>1142065</stored-value></pair>
+      <pair><displayed-value>Mayo, John W.</displayed-value><stored-value>224924</stored-value></pair>
+      <pair><displayed-value>McAllester, David</displayed-value><stored-value>1142081</stored-value></pair>
+      <pair><displayed-value>McAllister, Patrick</displayed-value><stored-value>1150427</stored-value></pair>
+      <pair><displayed-value>McAndrews, James</displayed-value><stored-value>44684</stored-value></pair>
+      <pair><displayed-value>McCabe, Mark J.</displayed-value><stored-value>357883</stored-value></pair>
+
+      <pair><displayed-value>McCracken, Paul W.</displayed-value><stored-value>713997</stored-value></pair>
+      <pair><displayed-value>McCullough, Bruce D.</displayed-value><stored-value>328094</stored-value></pair>
+      <pair><displayed-value>McDowell, Jhon</displayed-value><stored-value>1147628</stored-value></pair>
+      <pair><displayed-value>McDowell, John M.</displayed-value><stored-value>276492</stored-value></pair>
+      <pair><displayed-value>McVay, Monte</displayed-value><stored-value>1143306</stored-value></pair>
+      <pair><displayed-value>McVay, Sarah E.</displayed-value><stored-value>333097</stored-value></pair>
+
+      <pair><displayed-value>Mcskassy, Sofus</displayed-value><stored-value>1131947</stored-value></pair>
+      <pair><displayed-value>Mehran, Hamid</displayed-value><stored-value>15840</stored-value></pair>
+      <pair><displayed-value>Mei, Jiangping</displayed-value><stored-value>1148433</stored-value></pair>
+      <pair><displayed-value>Mei, Jianping</displayed-value><stored-value>17637</stored-value></pair>
+      <pair><displayed-value>Mei, Jianping (J.P.)</displayed-value><stored-value>1152392</stored-value></pair>
+      <pair><displayed-value>Mendelson, Haim</displayed-value><stored-value>85588</stored-value></pair>
+
+      <pair><displayed-value>Mendenhall, Richard R.</displayed-value><stored-value>16859</stored-value></pair>
+      <pair><displayed-value>Menicucci, Domenico</displayed-value><stored-value>332952</stored-value></pair>
+      <pair><displayed-value>Menkveld, Albert J.</displayed-value><stored-value>49904</stored-value></pair>
+      <pair><displayed-value>Menon, Geeta</displayed-value><stored-value>505839</stored-value></pair>
+      <pair><displayed-value>Merrick, John J.</displayed-value><stored-value>327360</stored-value></pair>
+      <pair><displayed-value>Merrick, Jr. John J.</displayed-value><stored-value>1152394</stored-value></pair>
+
+      <pair><displayed-value>Merten, Alan C.</displayed-value><stored-value>1143305</stored-value></pair>
+      <pair><displayed-value>Merten, Alan G.</displayed-value><stored-value>1143308</stored-value></pair>
+      <pair><displayed-value>Meyvis, Tom</displayed-value><stored-value>713366</stored-value></pair>
+      <pair><displayed-value>Meza, Sergio</displayed-value><stored-value>116911</stored-value></pair>
+      <pair><displayed-value>Mezias, John M.</displayed-value><stored-value>345905</stored-value></pair>
+      <pair><displayed-value>Michaels, Robert J.</displayed-value><stored-value>246977</stored-value></pair>
+
+      <pair><displayed-value>Michaely, Roni</displayed-value><stored-value>16133</stored-value></pair>
+      <pair><displayed-value>Michielse, Ken</displayed-value><stored-value>1143453</stored-value></pair>
+      <pair><displayed-value>Milgrom, Paul R.</displayed-value><stored-value>22848</stored-value></pair>
+      <pair><displayed-value>Miller, James C.</displayed-value><stored-value>65908</stored-value></pair>
+      <pair><displayed-value>Miravete, Eugenio J.</displayed-value><stored-value>21475</stored-value></pair>
+      <pair><displayed-value>Mistry, Abhishek</displayed-value><stored-value>1222846</stored-value></pair>
+
+      <pair><displayed-value>Mitra, Prasenjit</displayed-value><stored-value>551429</stored-value></pair>
+      <pair><displayed-value>Mohanram, Partha S.</displayed-value><stored-value>152633</stored-value></pair>
+      <pair><displayed-value>Mojarad, Sarah M</displayed-value><stored-value>1195265</stored-value></pair>
+      <pair><displayed-value>Moloche, Guillermo</displayed-value><stored-value>347909</stored-value></pair>
+      <pair><displayed-value>Morck, Randall</displayed-value><stored-value>71368</stored-value></pair>
+      <pair><displayed-value>Morey, Richard R</displayed-value><stored-value>430596</stored-value></pair>
+
+      <pair><displayed-value>Morrin, Maureen</displayed-value><stored-value>231381</stored-value></pair>
+      <pair><displayed-value>Morris, Anthony</displayed-value><stored-value>571288</stored-value></pair>
+      <pair><displayed-value>Morwitz, Vicki</displayed-value><stored-value>95189</stored-value></pair>
+      <pair><displayed-value>Moser, James T.</displayed-value><stored-value>16296</stored-value></pair>
+      <pair><displayed-value>Moses, Michael</displayed-value><stored-value>331714</stored-value></pair>
+      <pair><displayed-value>Moulines, Eric</displayed-value><stored-value>342788</stored-value></pair>
+
+      <pair><displayed-value>Muehlfeld, Katrin</displayed-value><stored-value>415922</stored-value></pair>
+      <pair><displayed-value>Mueller, Holger M.</displayed-value><stored-value>163369</stored-value></pair>
+      <pair><displayed-value>Mukhopadhyay, Tridas</displayed-value><stored-value>264189</stored-value></pair>
+      <pair><displayed-value>Mulani, Sunil</displayed-value><stored-value>429440</stored-value></pair>
+      <pair><displayed-value>Muller, Holger M.</displayed-value><stored-value>1148142</stored-value></pair>
+      <pair><displayed-value>Musto, David K.</displayed-value><stored-value>205891</stored-value></pair>
+
+      <pair><displayed-value>Myers, Stewart C.</displayed-value><stored-value>17423</stored-value></pair>
+      <pair><displayed-value>M¬∏ller, Holger M.</displayed-value><stored-value>1148427</stored-value></pair>
+      <pair><displayed-value>N. Harris, Mark</displayed-value><stored-value>1132670</stored-value></pair>
+      <pair><displayed-value>NEELANKAVIL, JAMES P.</displayed-value><stored-value>1147616</stored-value></pair>
+      <pair><displayed-value>Nagar, Venky</displayed-value><stored-value>150861</stored-value></pair>
+      <pair><displayed-value>Nagarajan, S.</displayed-value><stored-value>1149006</stored-value></pair>
+
+      <pair><displayed-value>Nagel, Stefan</displayed-value><stored-value>276811</stored-value></pair>
+      <pair><displayed-value>Naik, Narayan Y.</displayed-value><stored-value>41033</stored-value></pair>
+      <pair><displayed-value>Nair, Vinay B.</displayed-value><stored-value>88994</stored-value></pair>
+      <pair><displayed-value>Nalebuff, Barry</displayed-value><stored-value>36229</stored-value></pair>
+      <pair><displayed-value>Nam, Kwanghee</displayed-value><stored-value>137418</stored-value></pair>
+      <pair><displayed-value>Nam, Seunghan</displayed-value><stored-value>391569</stored-value></pair>
+
+      <pair><displayed-value>Nanda, Harsh</displayed-value><stored-value>1133323</stored-value></pair>
+      <pair><displayed-value>Nanda, Vikram K.</displayed-value><stored-value>17302</stored-value></pair>
+      <pair><displayed-value>Nandy, Debarshi</displayed-value><stored-value>205512</stored-value></pair>
+      <pair><displayed-value>Napp, Clotilde</displayed-value><stored-value>648933</stored-value></pair>
+      <pair><displayed-value>Narayanan, Paul</displayed-value><stored-value>686554</stored-value></pair>
+      <pair><displayed-value>Narayanan, Ranga</displayed-value><stored-value>45905</stored-value></pair>
+
+      <pair><displayed-value>Nashikkar, Amrut J.</displayed-value><stored-value>596984</stored-value></pair>
+      <pair><displayed-value>Natalucci, Fabio Massimo</displayed-value><stored-value>91443</stored-value></pair>
+      <pair><displayed-value>Neal, Terry L.</displayed-value><stored-value>51250</stored-value></pair>
+      <pair><displayed-value>Nelson, Lee</displayed-value><stored-value>1151915</stored-value></pair>
+      <pair><displayed-value>Nelson, Leif D.</displayed-value><stored-value>713396</stored-value></pair>
+      <pair><displayed-value>Nelson, Philip B</displayed-value><stored-value>390739</stored-value></pair>
+
+      <pair><displayed-value>Neslin, Scott</displayed-value><stored-value>266318</stored-value></pair>
+      <pair><displayed-value>Neuman, Irina</displayed-value><stored-value>1142946</stored-value></pair>
+      <pair><displayed-value>Neumeyer, Pablo A.</displayed-value><stored-value>371489</stored-value></pair>
+      <pair><displayed-value>Nielsen, Kasper Meisner</displayed-value><stored-value>333077</stored-value></pair>
+      <pair><displayed-value>Nieuwerburgh, Van</displayed-value><stored-value>1146521</stored-value></pair>
+      <pair><displayed-value>Nijman, Theo E.</displayed-value><stored-value>204454</stored-value></pair>
+
+      <pair><displayed-value>Niskanen, William A.</displayed-value><stored-value>59468</stored-value></pair>
+      <pair><displayed-value>Nissim, Doron</displayed-value><stored-value>161870</stored-value></pair>
+      <pair><displayed-value>Nordhaus, William D.</displayed-value><stored-value>96028</stored-value></pair>
+      <pair><displayed-value>Ntoulas, Alexandros</displayed-value><stored-value>1131960</stored-value></pair>
+      <pair><displayed-value>O'Callaghan, Ramon</displayed-value><stored-value>1135965</stored-value></pair>
+      <pair><displayed-value>O'Hara, Maureen</displayed-value><stored-value>16137</stored-value></pair>
+
+      <pair><displayed-value>Oates, Wallace</displayed-value><stored-value>249178</stored-value></pair>
+      <pair><displayed-value>Oestreicher-Singer, Gal</displayed-value><stored-value>565076</stored-value></pair>
+      <pair><displayed-value>Ofek, Eli</displayed-value><stored-value>15129</stored-value></pair>
+      <pair><displayed-value>Ofeka, Eli</displayed-value><stored-value>1148144</stored-value></pair>
+      <pair><displayed-value>Ogden, Joseph P.</displayed-value><stored-value>77772</stored-value></pair>
+      <pair><displayed-value>Ogneva, Maria</displayed-value><stored-value>370476</stored-value></pair>
+
+      <pair><displayed-value>Oh, Wonseok</displayed-value><stored-value>415754</stored-value></pair>
+      <pair><displayed-value>Ohanian, Lee E.</displayed-value><stored-value>15006</stored-value></pair>
+      <pair><displayed-value>Ohlson, James A.</displayed-value><stored-value>825636</stored-value></pair>
+      <pair><displayed-value>Ohno, Saburo</displayed-value><stored-value>680542</stored-value></pair>
+      <pair><displayed-value>Okunev, John</displayed-value><stored-value>27496</stored-value></pair>
+      <pair><displayed-value>Olson, Margrethe</displayed-value><stored-value>1141330</stored-value></pair>
+
+      <pair><displayed-value>Onorato, Mario</displayed-value><stored-value>341096</stored-value></pair>
+      <pair><displayed-value>Oppenheimer, Daniel M.</displayed-value><stored-value>845610</stored-value></pair>
+      <pair><displayed-value>Orazem, Peter Francis</displayed-value><stored-value>36060</stored-value></pair>
+      <pair><displayed-value>Ordover, Janusz A.</displayed-value><stored-value>78992</stored-value></pair>
+      <pair><displayed-value>Orlikowski, Wanda J.</displayed-value><stored-value>25830</stored-value></pair>
+      <pair><displayed-value>Oswald, Dennis R.</displayed-value><stored-value>328933</stored-value></pair>
+
+      <pair><displayed-value>Otsuki, Toshiyuki</displayed-value><stored-value>67456</stored-value></pair>
+      <pair><displayed-value>Ou, Ernest Y.</displayed-value><stored-value>332311</stored-value></pair>
+      <pair><displayed-value>Ou-Yang, Hui</displayed-value><stored-value>295767</stored-value></pair>
+      <pair><displayed-value>Owen, Bruce M.</displayed-value><stored-value>80492</stored-value></pair>
+      <pair><displayed-value>Owen, Guillermo</displayed-value><stored-value>47243</stored-value></pair>
+      <pair><displayed-value>Owen, Joel</displayed-value><stored-value>104168</stored-value></pair>
+
+      <pair><displayed-value>Owens, Karl R.</displayed-value><stored-value>1143345</stored-value></pair>
+      <pair><displayed-value>Ozdaglar, Asuman E.</displayed-value><stored-value>452354</stored-value></pair>
+      <pair><displayed-value>Ozelge, Sadi</displayed-value><stored-value>655515</stored-value></pair>
+      <pair><displayed-value>Pacheco-de-Almeida, Gon√Åalo</displayed-value><stored-value>328265</stored-value></pair>
+      <pair><displayed-value>Padberg, M.</displayed-value><stored-value>1144326</stored-value></pair>
+      <pair><displayed-value>Padmanabhan, Balaji</displayed-value><stored-value>666707</stored-value></pair>
+
+      <pair><displayed-value>Padmanabhan, Paddy V.</displayed-value><stored-value>328096</stored-value></pair>
+      <pair><displayed-value>Padmanabhan, Prasad</displayed-value><stored-value>301018</stored-value></pair>
+      <pair><displayed-value>Padrnanabhan, Balaji</displayed-value><stored-value>1137349</stored-value></pair>
+      <pair><displayed-value>Paik, Tae-Young</displayed-value><stored-value>62892</stored-value></pair>
+      <pair><displayed-value>Palia, Darius</displayed-value><stored-value>143463</stored-value></pair>
+      <pair><displayed-value>Palley, Michael</displayed-value><stored-value>447168</stored-value></pair>
+
+      <pair><displayed-value>Pan, Xin</displayed-value><stored-value>1060697</stored-value></pair>
+      <pair><displayed-value>Pantzalis, Christos</displayed-value><stored-value>223540</stored-value></pair>
+      <pair><displayed-value>Panunzi, Fausto</displayed-value><stored-value>368608</stored-value></pair>
+      <pair><displayed-value>Pardo, ‚àö?ngel</displayed-value><stored-value>1148431</stored-value></pair>
+      <pair><displayed-value>Park, James M.</displayed-value><stored-value>67971</stored-value></pair>
+      <pair><displayed-value>Park, Sang Yong</displayed-value><stored-value>597160</stored-value></pair>
+
+      <pair><displayed-value>Park, Young-Hoon</displayed-value><stored-value>117020</stored-value></pair>
+      <pair><displayed-value>Paroush, Jacob</displayed-value><stored-value>32045</stored-value></pair>
+      <pair><displayed-value>Pascual, Roberto</displayed-value><stored-value>1148429</stored-value></pair>
+      <pair><displayed-value>Paskov, Spassimir H.</displayed-value><stored-value>16069</stored-value></pair>
+      <pair><displayed-value>Pasquariello, Paolo</displayed-value><stored-value>250093</stored-value></pair>
+      <pair><displayed-value>Passell, Peter</displayed-value><stored-value>200190</stored-value></pair>
+
+      <pair><displayed-value>Pasternack, Brent</displayed-value><stored-value>707612</stored-value></pair>
+      <pair><displayed-value>Patton, Andrew J.</displayed-value><stored-value>205520</stored-value></pair>
+      <pair><displayed-value>Paul, Sharoda</displayed-value><stored-value>554695</stored-value></pair>
+      <pair><displayed-value>Pavlova, Anna</displayed-value><stored-value>242365</stored-value></pair>
+      <pair><displayed-value>Pazgal, Amit I.</displayed-value><stored-value>73057</stored-value></pair>
+      <pair><displayed-value>Pedersen, Lasse Heje</displayed-value><stored-value>277060</stored-value></pair>
+
+      <pair><displayed-value>Pedersenz, Lasse Heje</displayed-value><stored-value>1153789</stored-value></pair>
+      <pair><displayed-value>Peltzman, Sam</displayed-value><stored-value>93807</stored-value></pair>
+      <pair><displayed-value>Peracchi, Franco</displayed-value><stored-value>236452</stored-value></pair>
+      <pair><displayed-value>Pereira, Pedro</displayed-value><stored-value>440910</stored-value></pair>
+      <pair><displayed-value>Pereira, Pedro</displayed-value><stored-value>450770</stored-value></pair>
+      <pair><displayed-value>Perez Saiz, Hector</displayed-value><stored-value>423622</stored-value></pair>
+
+      <pair><displayed-value>Perez-Gonzalez, Francisco</displayed-value><stored-value>332689</stored-value></pair>
+      <pair><displayed-value>Peristiani, Stavros</displayed-value><stored-value>45041</stored-value></pair>
+      <pair><displayed-value>Perlich, Claudia</displayed-value><stored-value>372822</stored-value></pair>
+      <pair><displayed-value>Pern√åas, Jos√à C.</displayed-value><stored-value>390222</stored-value></pair>
+      <pair><displayed-value>Perri, Fabrizio</displayed-value><stored-value>242468</stored-value></pair>
+      <pair><displayed-value>Peters, Edward</displayed-value><stored-value>1135984</stored-value></pair>
+
+      <pair><displayed-value>Peters, James</displayed-value><stored-value>1143035</stored-value></pair>
+      <pair><displayed-value>Peterson, Sandra</displayed-value><stored-value>136693</stored-value></pair>
+      <pair><displayed-value>Petroni, Kathy Ruby</displayed-value><stored-value>17538</stored-value></pair>
+      <pair><displayed-value>Petrovits, Christine</displayed-value><stored-value>571844</stored-value></pair>
+      <pair><displayed-value>Phaneuf, Louis</displayed-value><stored-value>63610</stored-value></pair>
+      <pair><displayed-value>Philip G., Berger</displayed-value><stored-value>1151304</stored-value></pair>
+
+      <pair><displayed-value>Philippon, Thomas</displayed-value><stored-value>266888</stored-value></pair>
+      <pair><displayed-value>Phillips, Joan M.</displayed-value><stored-value>713469</stored-value></pair>
+      <pair><displayed-value>Phillips, Peter C.B.</displayed-value><stored-value>157372</stored-value></pair>
+      <pair><displayed-value>Pindyck, Robert S.</displayed-value><stored-value>25841</stored-value></pair>
+      <pair><displayed-value>Pinedo, Michael</displayed-value><stored-value>403012</stored-value></pair>
+      <pair><displayed-value>Pinkus, Allan</displayed-value><stored-value>1141335</stored-value></pair>
+
+      <pair><displayed-value>Pirrong, Craig</displayed-value><stored-value>134468</stored-value></pair>
+      <pair><displayed-value>Piskorski, Tomasz</displayed-value><stored-value>780120</stored-value></pair>
+      <pair><displayed-value>Pita Barros, Pedro Luis</displayed-value><stored-value>55671</stored-value></pair>
+      <pair><displayed-value>Plambeck, Erica L.</displayed-value><stored-value>347793</stored-value></pair>
+      <pair><displayed-value>Plerou, Vasiliki</displayed-value><stored-value>347407</stored-value></pair>
+      <pair><displayed-value>Plimpton, Rodney B.</displayed-value><stored-value>1143342</stored-value></pair>
+
+      <pair><displayed-value>Pojarliev, Momtchil T.</displayed-value><stored-value>272750</stored-value></pair>
+      <pair><displayed-value>Polak, Ben</displayed-value><stored-value>1132675</stored-value></pair>
+      <pair><displayed-value>Polak, Benjamin</displayed-value><stored-value>57809</stored-value></pair>
+      <pair><displayed-value>Poltrack, David F.</displayed-value><stored-value>713360</stored-value></pair>
+      <pair><displayed-value>Pope, Peter F.</displayed-value><stored-value>53330</stored-value></pair>
+      <pair><displayed-value>Popkowski Leszczyc, Peter T. L.</displayed-value><stored-value>441780</stored-value></pair>
+
+      <pair><displayed-value>Pople, Harry E.</displayed-value><stored-value>1142962</stored-value></pair>
+      <pair><displayed-value>Portney, Paul R.</displayed-value><stored-value>96030</stored-value></pair>
+      <pair><displayed-value>Poteshman, Allen M.</displayed-value><stored-value>238388</stored-value></pair>
+      <pair><displayed-value>Pot√è, Valerio</displayed-value><stored-value>345615</stored-value></pair>
+      <pair><displayed-value>Prabhala, N. R.</displayed-value><stored-value>1153782</stored-value></pair>
+      <pair><displayed-value>Prabhu, Ajit M.</displayed-value><stored-value>1135947</stored-value></pair>
+
+      <pair><displayed-value>Presentation, Sales</displayed-value><stored-value>808690</stored-value></pair>
+      <pair><displayed-value>Prieger, James E.</displayed-value><stored-value>297790</stored-value></pair>
+      <pair><displayed-value>Provost, Foster</displayed-value><stored-value>691208</stored-value></pair>
+      <pair><displayed-value>Pukthuanthong, Kuntara</displayed-value><stored-value>330093</stored-value></pair>
+      <pair><displayed-value>Pukthuanthong-Le, Kuntara</displayed-value><stored-value>1147624</stored-value></pair>
+      <pair><displayed-value>Purao, Sandeep</displayed-value><stored-value>550596</stored-value></pair>
+
+      <pair><displayed-value>Puri, Manju</displayed-value><stored-value>17585</stored-value></pair>
+      <pair><displayed-value>Putsis, William P.</displayed-value><stored-value>194450</stored-value></pair>
+      <pair><displayed-value>Pyun, Jisurk</displayed-value><stored-value>1142956</stored-value></pair>
+      <pair><displayed-value>Qian, Yiming</displayed-value><stored-value>337776</stored-value></pair>
+      <pair><displayed-value>Quadrini, Vincenzo</displayed-value><stored-value>128009</stored-value></pair>
+      <pair><displayed-value>Quayle, Casey</displayed-value><stored-value>1143309</stored-value></pair>
+
+      <pair><displayed-value>Quintos, Carmela</displayed-value><stored-value>41760</stored-value></pair>
+      <pair><displayed-value>Quiohilag, Ainsley</displayed-value><stored-value>1133330</stored-value></pair>
+      <pair><displayed-value>Radhakrishnan, R A</displayed-value><stored-value>1151907</stored-value></pair>
+      <pair><displayed-value>Radhakrishnan, Suresh</displayed-value><stored-value>20904</stored-value></pair>
+      <pair><displayed-value>Radner, Roy</displayed-value><stored-value>20784</stored-value></pair>
+      <pair><displayed-value>Raghubir, Priya</displayed-value><stored-value>351205</stored-value></pair>
+
+      <pair><displayed-value>Raghunathan, Rajagopal</displayed-value><stored-value>493117</stored-value></pair>
+      <pair><displayed-value>Rai, Atul</displayed-value><stored-value>242331</stored-value></pair>
+      <pair><displayed-value>Rajan, Raghuram G.</displayed-value><stored-value>2096</stored-value></pair>
+      <pair><displayed-value>Rajan, Uday</displayed-value><stored-value>140429</stored-value></pair>
+      <pair><displayed-value>Ramachandran, Vandana</displayed-value><stored-value>396373</stored-value></pair>
+      <pair><displayed-value>Ramadorai, Tarun</displayed-value><stored-value>267374</stored-value></pair>
+
+      <pair><displayed-value>Raman, Ananth</displayed-value><stored-value>59241</stored-value></pair>
+      <pair><displayed-value>Ramanathan, Suresh</displayed-value><stored-value>505834</stored-value></pair>
+      <pair><displayed-value>Rampini, Adriano A.</displayed-value><stored-value>253584</stored-value></pair>
+      <pair><displayed-value>Ramsey, James B.</displayed-value><stored-value>17579</stored-value></pair>
+      <pair><displayed-value>Ranciere, Romain</displayed-value><stored-value>328239</stored-value></pair>
+      <pair><displayed-value>Ranganathan, Nicky</displayed-value><stored-value>1142947</stored-value></pair>
+
+      <pair><displayed-value>Ranganathan, P.</displayed-value><stored-value>1142961</stored-value></pair>
+      <pair><displayed-value>Ranganathan, Padmanabhan</displayed-value><stored-value>1143307</stored-value></pair>
+      <pair><displayed-value>Rangel, J. Gonzalo</displayed-value><stored-value>1151299</stored-value></pair>
+      <pair><displayed-value>Rangel, Jose Gonzalo</displayed-value><stored-value>697767</stored-value></pair>
+      <pair><displayed-value>Rangel, Jose Gonzalo</displayed-value><stored-value>375273</stored-value></pair>
+      <pair><displayed-value>Rao, Ahobala</displayed-value><stored-value>1142964</stored-value></pair>
+
+      <pair><displayed-value>Rattanaruengyot, Thongchai</displayed-value><stored-value>1334985</stored-value></pair>
+      <pair><displayed-value>Ravid, Abraham S</displayed-value><stored-value>1150544</stored-value></pair>
+      <pair><displayed-value>Ravid, Abraham S.</displayed-value><stored-value>1150543</stored-value></pair>
+      <pair><displayed-value>Ravid, S. Abraham</displayed-value><stored-value>1150545</stored-value></pair>
+      <pair><displayed-value>Ravina, Enrichetta</displayed-value><stored-value>597462</stored-value></pair>
+      <pair><displayed-value>Raviv, Alon</displayed-value><stored-value>342912</stored-value></pair>
+
+      <pair><displayed-value>Rawley, Evan</displayed-value><stored-value>862962</stored-value></pair>
+      <pair><displayed-value>Ray, Bonnie K.</displayed-value><stored-value>529197</stored-value></pair>
+      <pair><displayed-value>Razin, Ronny</displayed-value><stored-value>105266</stored-value></pair>
+      <pair><displayed-value>Refalo, James F.</displayed-value><stored-value>149073</stored-value></pair>
+      <pair><displayed-value>Register, Charles A.</displayed-value><stored-value>124772</stored-value></pair>
+      <pair><displayed-value>Reisz, Alexander</displayed-value><stored-value>428245</stored-value></pair>
+
+      <pair><displayed-value>Reitman, Walter</displayed-value><stored-value>1143457</stored-value></pair>
+      <pair><displayed-value>Reitman Olson, Judith</displayed-value><stored-value>1143304</stored-value></pair>
+      <pair><displayed-value>Remmers, Barbara</displayed-value><stored-value>68508</stored-value></pair>
+      <pair><displayed-value>Ren√ö, Roberto</displayed-value><stored-value>327190</stored-value></pair>
+      <pair><displayed-value>Research Paper Series, NYU Law</displayed-value><stored-value>419245</stored-value></pair>
+      <pair><displayed-value>Research Paper Series, Ross School of Business</displayed-value><stored-value>561150</stored-value></pair>
+
+      <pair><displayed-value>Research Submitter, Harvard Institute of Economic</displayed-value><stored-value>1289180</stored-value></pair>
+      <pair><displayed-value>Reshef, Ariell</displayed-value><stored-value>376586</stored-value></pair>
+      <pair><displayed-value>Resti, Andrea</displayed-value><stored-value>223524</stored-value></pair>
+      <pair><displayed-value>Rezende, Leonardo</displayed-value><stored-value>699878</stored-value></pair>
+      <pair><displayed-value>Rhine, Sherrie L.W.</displayed-value><stored-value>343137</stored-value></pair>
+      <pair><displayed-value>Ribeiro, Ricardo</displayed-value><stored-value>875172</stored-value></pair>
+
+      <pair><displayed-value>Ribeiro, Tiago</displayed-value><stored-value>90749</stored-value></pair>
+      <pair><displayed-value>Richardson, Matthew P.</displayed-value><stored-value>42753</stored-value></pair>
+      <pair><displayed-value>Richardson, Thomas J.</displayed-value><stored-value>352042</stored-value></pair>
+      <pair><displayed-value>Ricks, William E.</displayed-value><stored-value>183332</stored-value></pair>
+      <pair><displayed-value>Rijken, Herbert A.</displayed-value><stored-value>687152</stored-value></pair>
+      <pair><displayed-value>Ripston, Beth A.</displayed-value><stored-value>207829</stored-value></pair>
+
+      <pair><displayed-value>Rivlin, Alice</displayed-value><stored-value>382409</stored-value></pair>
+      <pair><displayed-value>Rocheteau, Guillaume</displayed-value><stored-value>302506</stored-value></pair>
+      <pair><displayed-value>Rock, Edward B.</displayed-value><stored-value>44766</stored-value></pair>
+      <pair><displayed-value>Rockoff, Maxine L.</displayed-value><stored-value>1142070</stored-value></pair>
+      <pair><displayed-value>Rodriguez, Juan Carlos</displayed-value><stored-value>352545</stored-value></pair>
+      <pair><displayed-value>Rollier, Bruce</displayed-value><stored-value>1141332</stored-value></pair>
+
+      <pair><displayed-value>Ronen, Boaz</displayed-value><stored-value>350484</stored-value></pair>
+      <pair><displayed-value>Roomans, Mark</displayed-value><stored-value>183608</stored-value></pair>
+      <pair><displayed-value>Rosen, Harvey S.</displayed-value><stored-value>92890</stored-value></pair>
+      <pair><displayed-value>Rosenberg, Joshua V.</displayed-value><stored-value>44290</stored-value></pair>
+      <pair><displayed-value>Rosenfeld, James</displayed-value><stored-value>44449</stored-value></pair>
+      <pair><displayed-value>Ross, Stephen A.</displayed-value><stored-value>26373</stored-value></pair>
+
+      <pair><displayed-value>Ross, Thomas W.</displayed-value><stored-value>938481</stored-value></pair>
+      <pair><displayed-value>Rosset, Saharon</displayed-value><stored-value>1131948</stored-value></pair>
+      <pair><displayed-value>Rosston, Gregory L.</displayed-value><stored-value>332917</stored-value></pair>
+      <pair><displayed-value>Rotem, Doron</displayed-value><stored-value>1133795</stored-value></pair>
+      <pair><displayed-value>Rothkopf, Michael H.</displayed-value><stored-value>17905</stored-value></pair>
+      <pair><displayed-value>Rousseau, Peter L.</displayed-value><stored-value>66255</stored-value></pair>
+
+      <pair><displayed-value>Roy, Ritendra</displayed-value><stored-value>1133335</stored-value></pair>
+      <pair><displayed-value>Ruback, Richard S.</displayed-value><stored-value>58677</stored-value></pair>
+      <pair><displayed-value>Russell, Jeffrey R.</displayed-value><stored-value>16081</stored-value></pair>
+      <pair><displayed-value>Russell, Milton</displayed-value><stored-value>711565</stored-value></pair>
+      <pair><displayed-value>Ruta, Sebastian</displayed-value><stored-value>1133338</stored-value></pair>
+      <pair><displayed-value>Ruthenberg, David</displayed-value><stored-value>451347</stored-value></pair>
+
+      <pair><displayed-value>Ryan, Joe</displayed-value><stored-value>405104</stored-value></pair>
+      <pair><displayed-value>Ryan, Stephen</displayed-value><stored-value>404883</stored-value></pair>
+      <pair><displayed-value>Ryan, Stephen G.</displayed-value><stored-value>20955</stored-value></pair>
+      <pair><displayed-value>Rysman, Marc</displayed-value><stored-value>274698</stored-value></pair>
+      <pair><displayed-value>SMITH, Ronn J.</displayed-value><stored-value>882537</stored-value></pair>
+      <pair><displayed-value>SPROTT, David</displayed-value><stored-value>882539</stored-value></pair>
+
+      <pair><displayed-value>Saar, Gideon</displayed-value><stored-value>245988</stored-value></pair>
+      <pair><displayed-value>Saar-Tsechansky, Maytal</displayed-value><stored-value>691185</stored-value></pair>
+      <pair><displayed-value>Saar-Tsechansky, Maytal</displayed-value><stored-value>1133979</stored-value></pair>
+      <pair><displayed-value>Sabato, Gabriele</displayed-value><stored-value>451378</stored-value></pair>
+      <pair><displayed-value>Sade, Orly</displayed-value><stored-value>291969</stored-value></pair>
+      <pair><displayed-value>Saggi, Kamal</displayed-value><stored-value>119671</stored-value></pair>
+
+      <pair><displayed-value>Sajeesh, S.</displayed-value><stored-value>996882</stored-value></pair>
+      <pair><displayed-value>Salant, David J.</displayed-value><stored-value>537210</stored-value></pair>
+      <pair><displayed-value>Salinger, Michael A.</displayed-value><stored-value>701757</stored-value></pair>
+      <pair><displayed-value>Sangvinatsos, Antonios A.</displayed-value><stored-value>352547</stored-value></pair>
+      <pair><displayed-value>Sankaranarayanan, Ramesh</displayed-value><stored-value>363750</stored-value></pair>
+      <pair><displayed-value>Sankaranarayanan, Ramesh</displayed-value><stored-value>499322</stored-value></pair>
+
+      <pair><displayed-value>Sannikov, Yuliy</displayed-value><stored-value>382854</stored-value></pair>
+      <pair><displayed-value>Santos, Jo‚Äûo A.C.</displayed-value><stored-value>103125</stored-value></pair>
+      <pair><displayed-value>Sapienza, Paola</displayed-value><stored-value>73429</stored-value></pair>
+      <pair><displayed-value>Sarath, Bharat</displayed-value><stored-value>50181</stored-value></pair>
+      <pair><displayed-value>Sarkar, Debojyoti</displayed-value><stored-value>80669</stored-value></pair>
+      <pair><displayed-value>Sasso, William C.</displayed-value><stored-value>1142957</stored-value></pair>
+
+      <pair><displayed-value>Satchell, Stephen E.</displayed-value><stored-value>44149</stored-value></pair>
+      <pair><displayed-value>Saunders, Anthony</displayed-value><stored-value>17647</stored-value></pair>
+      <pair><displayed-value>Saundersc, Anthony</displayed-value><stored-value>1148141</stored-value></pair>
+      <pair><displayed-value>Savage, Scott</displayed-value><stored-value>232519</stored-value></pair>
+      <pair><displayed-value>Savitsky, Kenneth</displayed-value><stored-value>713371</stored-value></pair>
+      <pair><displayed-value>Saxena, Shivanker</displayed-value><stored-value>1133326</stored-value></pair>
+
+      <pair><displayed-value>Sbuelz, Alessandro</displayed-value><stored-value>103773</stored-value></pair>
+      <pair><displayed-value>Scalise, Joseph M.</displayed-value><stored-value>43800</stored-value></pair>
+      <pair><displayed-value>Schanzenbach, Max Matthew</displayed-value><stored-value>346044</stored-value></pair>
+      <pair><displayed-value>Scheinkman, Jose A.</displayed-value><stored-value>173218</stored-value></pair>
+      <pair><displayed-value>Schilling, Melissa A.</displayed-value><stored-value>341752</stored-value></pair>
+      <pair><displayed-value>Schmalensee, Richard</displayed-value><stored-value>21576</stored-value></pair>
+
+      <pair><displayed-value>Schmid, Markus Max</displayed-value><stored-value>362677</stored-value></pair>
+      <pair><displayed-value>Schmidt, Joachim W.</displayed-value><stored-value>1143311</stored-value></pair>
+      <pair><displayed-value>Schmit, Joey J</displayed-value><stored-value>688478</stored-value></pair>
+      <pair><displayed-value>Schocken, Shimon</displayed-value><stored-value>1135973</stored-value></pair>
+      <pair><displayed-value>Schocken, Shirnon</displayed-value><stored-value>1142075</stored-value></pair>
+      <pair><displayed-value>Scholnick, Barry</displayed-value><stored-value>342904</stored-value></pair>
+
+      <pair><displayed-value>School of Business Research Paper Series, Robert H. Smith</displayed-value><stored-value>603680</stored-value></pair>
+      <pair><displayed-value>Schotmanz, Peter</displayed-value><stored-value>1151302</stored-value></pair>
+      <pair><displayed-value>Schreiber, Ben Z.</displayed-value><stored-value>57196</stored-value></pair>
+      <pair><displayed-value>Schuermann, Til</displayed-value><stored-value>145572</stored-value></pair>
+      <pair><displayed-value>Schularick, Moritz</displayed-value><stored-value>585594</stored-value></pair>
+      <pair><displayed-value>Schultz, Randall</displayed-value><stored-value>364229</stored-value></pair>
+
+      <pair><displayed-value>Schultze, Charles L.</displayed-value><stored-value>31227</stored-value></pair>
+      <pair><displayed-value>Schwartz, Robert A.</displayed-value><stored-value>50162</stored-value></pair>
+      <pair><displayed-value>Schwarz, Christopher</displayed-value><stored-value>655127</stored-value></pair>
+      <pair><displayed-value>Schwarz, Christopher</displayed-value><stored-value>1155876</stored-value></pair>
+      <pair><displayed-value>Sealey, C.W.</displayed-value><stored-value>1149007</stored-value></pair>
+      <pair><displayed-value>Seethamraju, Chandrakanth</displayed-value><stored-value>267929</stored-value></pair>
+
+      <pair><displayed-value>Segal, Benjamin</displayed-value><stored-value>373065</stored-value></pair>
+      <pair><displayed-value>Segal, Dan</displayed-value><stored-value>340489</stored-value></pair>
+      <pair><displayed-value>Segev, Arie</displayed-value><stored-value>20473</stored-value></pair>
+      <pair><displayed-value>Seidmann, Abraham</displayed-value><stored-value>17414</stored-value></pair>
+      <pair><displayed-value>Seidmann, Abraham</displayed-value><stored-value>833504</stored-value></pair>
+      <pair><displayed-value>Seim, Katja</displayed-value><stored-value>341307</stored-value></pair>
+
+      <pair><displayed-value>Seim (Stanford), Katja</displayed-value><stored-value>1133343</stored-value></pair>
+      <pair><displayed-value>Sela, Rebecca J.</displayed-value><stored-value>400970</stored-value></pair>
+      <pair><displayed-value>Semmler, Willi</displayed-value><stored-value>22501</stored-value></pair>
+      <pair><displayed-value>Sen, Shahana</displayed-value><stored-value>419395</stored-value></pair>
+      <pair><displayed-value>Sen, Subrata K.</displayed-value><stored-value>263770</stored-value></pair>
+      <pair><displayed-value>Senbet, Lemma W.</displayed-value><stored-value>16654</stored-value></pair>
+
+      <pair><displayed-value>Sengupta, Anirban</displayed-value><stored-value>602010</stored-value></pair>
+      <pair><displayed-value>Sengupta, Bhaskar</displayed-value><stored-value>1147607</stored-value></pair>
+      <pair><displayed-value>Seppi, Duane J.</displayed-value><stored-value>15912</stored-value></pair>
+      <pair><displayed-value>Serfes, Konstantinos</displayed-value><stored-value>410122</stored-value></pair>
+      <pair><displayed-value>Seshadri, Sridhar</displayed-value><stored-value>357604</stored-value></pair>
+      <pair><displayed-value>Sessions, David N.</displayed-value><stored-value>197348</stored-value></pair>
+
+      <pair><displayed-value>Shakun, Melvin</displayed-value><stored-value>548112</stored-value></pair>
+      <pair><displayed-value>Shalev, Jacob</displayed-value><stored-value>1143323</stored-value></pair>
+      <pair><displayed-value>Shapira, Zur</displayed-value><stored-value>287062</stored-value></pair>
+      <pair><displayed-value>Shapiro, Alex</displayed-value><stored-value>159948</stored-value></pair>
+      <pair><displayed-value>Shavell, Steven</displayed-value><stored-value>17058</stored-value></pair>
+      <pair><displayed-value>Shelanski, Howard A.</displayed-value><stored-value>17257</stored-value></pair>
+
+      <pair><displayed-value>Shen, Michael</displayed-value><stored-value>458317</stored-value></pair>
+      <pair><displayed-value>Shen, YuQing</displayed-value><stored-value>1148424</stored-value></pair>
+      <pair><displayed-value>Sheng, Victor</displayed-value><stored-value>1131964</stored-value></pair>
+      <pair><displayed-value>Sheopuri, Anshul</displayed-value><stored-value>1143351</stored-value></pair>
+      <pair><displayed-value>Sheopuri, Dr. Anshul</displayed-value><stored-value>1147153</stored-value></pair>
+      <pair><displayed-value>Shephard, Neil</displayed-value><stored-value>74737</stored-value></pair>
+
+      <pair><displayed-value>Sheppard, Kevin</displayed-value><stored-value>287786</stored-value></pair>
+      <pair><displayed-value>Shi, Charles</displayed-value><stored-value>49308</stored-value></pair>
+      <pair><displayed-value>Shi, Shanming</displayed-value><stored-value>97515</stored-value></pair>
+      <pair><displayed-value>Shi, Yunfeng</displayed-value><stored-value>498239</stored-value></pair>
+      <pair><displayed-value>Shiftan, Joseph</displayed-value><stored-value>1142965</stored-value></pair>
+      <pair><displayed-value>Shillinglaw, Gordon</displayed-value><stored-value>1143322</stored-value></pair>
+
+      <pair><displayed-value>Shin, Hyun Song</displayed-value><stored-value>15041</stored-value></pair>
+      <pair><displayed-value>Shin, Hyun Song</displayed-value><stored-value>912778</stored-value></pair>
+      <pair><displayed-value>Shiraishi, Noriyoshi</displayed-value><stored-value>83708</stored-value></pair>
+      <pair><displayed-value>Shivdasani, Anil</displayed-value><stored-value>17540</stored-value></pair>
+      <pair><displayed-value>Shleifer, Andrei</displayed-value><stored-value>17066</stored-value></pair>
+      <pair><displayed-value>Short, James E.</displayed-value><stored-value>982630</stored-value></pair>
+
+      <pair><displayed-value>Shu, Jinghong</displayed-value><stored-value>1147160</stored-value></pair>
+      <pair><displayed-value>Sicker, Douglas</displayed-value><stored-value>417765</stored-value></pair>
+      <pair><displayed-value>Sidak, J. Gregory</displayed-value><stored-value>206474</stored-value></pair>
+      <pair><displayed-value>Silberschatz, Avi</displayed-value><stored-value>1142073</stored-value></pair>
+      <pair><displayed-value>Silver, Mark S.</displayed-value><stored-value>1137358</stored-value></pair>
+      <pair><displayed-value>Simaan, Yusif</displayed-value><stored-value>142768</stored-value></pair>
+
+      <pair><displayed-value>Simcoe, Timothy S.</displayed-value><stored-value>377924</stored-value></pair>
+      <pair><displayed-value>Simon, Bobe E.</displayed-value><stored-value>119010</stored-value></pair>
+      <pair><displayed-value>Simon, Gary</displayed-value><stored-value>415755</stored-value></pair>
+      <pair><displayed-value>Simonoff, Jeffrey S.</displayed-value><stored-value>1133781</stored-value></pair>
+      <pair><displayed-value>Singh, Nirvikar</displayed-value><stored-value>48355</stored-value></pair>
+      <pair><displayed-value>Singh, Rajdeep</displayed-value><stored-value>172368</stored-value></pair>
+
+      <pair><displayed-value>Singleton, Kenneth J.</displayed-value><stored-value>15716</stored-value></pair>
+      <pair><displayed-value>Sinha, Nishi</displayed-value><stored-value>20922</stored-value></pair>
+      <pair><displayed-value>Siniscalchi, Marciano</displayed-value><stored-value>165589</stored-value></pair>
+      <pair><displayed-value>Sironi, Andrea</displayed-value><stored-value>253494</stored-value></pair>
+      <pair><displayed-value>Sisli, Elif</displayed-value><stored-value>1155486</stored-value></pair>
+      <pair><displayed-value>Sisli Ciamarra, Elif</displayed-value><stored-value>476798</stored-value></pair>
+
+      <pair><displayed-value>Sitkoff, Robert H.</displayed-value><stored-value>230213</stored-value></pair>
+      <pair><displayed-value>Sivasankaran, Taracad</displayed-value><stored-value>1143318</stored-value></pair>
+      <pair><displayed-value>Skinner, Frank S.</displayed-value><stored-value>17652</stored-value></pair>
+      <pair><displayed-value>Skreta, Vasiliki</displayed-value><stored-value>402892</stored-value></pair>
+      <pair><displayed-value>Skrzypacz, Andrzej</displayed-value><stored-value>329310</stored-value></pair>
+      <pair><displayed-value>Slade, Stephen</displayed-value><stored-value>1137363</stored-value></pair>
+
+      <pair><displayed-value>Slaughter, Sandra</displayed-value><stored-value>370987</stored-value></pair>
+      <pair><displayed-value>Smith, Aaron D.</displayed-value><stored-value>106050</stored-value></pair>
+      <pair><displayed-value>Smith, Alastair</displayed-value><stored-value>1085021</stored-value></pair>
+      <pair><displayed-value>Smith, Michael D.</displayed-value><stored-value>291479</stored-value></pair>
+      <pair><displayed-value>Smith, Tom M.</displayed-value><stored-value>27446</stored-value></pair>
+      <pair><displayed-value>Smith, V. Kerry</displayed-value><stored-value>31972</stored-value></pair>
+
+      <pair><displayed-value>Smith, Vernon L.</displayed-value><stored-value>74192</stored-value></pair>
+      <pair><displayed-value>Snodgrass, Richard T.</displayed-value><stored-value>729120</stored-value></pair>
+      <pair><displayed-value>Snyder, Christopher M.</displayed-value><stored-value>782</stored-value></pair>
+      <pair><displayed-value>Soares, Jorge</displayed-value><stored-value>54267</stored-value></pair>
+      <pair><displayed-value>Sodini, Paolo</displayed-value><stored-value>286236</stored-value></pair>
+      <pair><displayed-value>Sohn, Bumjean</displayed-value><stored-value>673054</stored-value></pair>
+
+      <pair><displayed-value>Sokalska, Magdalena</displayed-value><stored-value>327383</stored-value></pair>
+      <pair><displayed-value>Soler, Montserrat</displayed-value><stored-value>657431</stored-value></pair>
+      <pair><displayed-value>Soliman, Mark T.</displayed-value><stored-value>276270</stored-value></pair>
+      <pair><displayed-value>Solow, Robert M.</displayed-value><stored-value>21582</stored-value></pair>
+      <pair><displayed-value>Song, Keke</displayed-value><stored-value>753418</stored-value></pair>
+      <pair><displayed-value>Sougiannis, Theodore</displayed-value><stored-value>15044</stored-value></pair>
+
+      <pair><displayed-value>Soulier, Philippe</displayed-value><stored-value>342789</stored-value></pair>
+      <pair><displayed-value>Souliery, Philippe</displayed-value><stored-value>1147612</stored-value></pair>
+      <pair><displayed-value>Spangenberg, Eric R.</displayed-value><stored-value>674332</stored-value></pair>
+      <pair><displayed-value>Sparrow, Ilana R.</displayed-value><stored-value>1143354</stored-value></pair>
+      <pair><displayed-value>Spear, Stephen E.</displayed-value><stored-value>331127</stored-value></pair>
+      <pair><displayed-value>Spiegel, Matthew I.</displayed-value><stored-value>987</stored-value></pair>
+
+      <pair><displayed-value>Spiegel, Yossi</displayed-value><stored-value>46040</stored-value></pair>
+      <pair><displayed-value>Spiller, Pablo T.</displayed-value><stored-value>16129</stored-value></pair>
+      <pair><displayed-value>Spindt, Paul A.</displayed-value><stored-value>21933</stored-value></pair>
+      <pair><displayed-value>Spitler, Valerie K.</displayed-value><stored-value>1135954</stored-value></pair>
+      <pair><displayed-value>Spitzer, Jonathan F.</displayed-value><stored-value>395259</stored-value></pair>
+      <pair><displayed-value>Spulber, Daniel F.</displayed-value><stored-value>31293</stored-value></pair>
+
+      <pair><displayed-value>Sraer, David</displayed-value><stored-value>1132953</stored-value></pair>
+      <pair><displayed-value>Srikanth, Rajan</displayed-value><stored-value>1142084</stored-value></pair>
+      <pair><displayed-value>Srinivasan, Anand</displayed-value><stored-value>505298</stored-value></pair>
+      <pair><displayed-value>Stacchetti, Ennio S.</displayed-value><stored-value>159550</stored-value></pair>
+      <pair><displayed-value>Stango, Victor</displayed-value><stored-value>243208</stored-value></pair>
+      <pair><displayed-value>Stanley, H. Eugene</displayed-value><stored-value>137873</stored-value></pair>
+
+      <pair><displayed-value>Stanton, Richard H.</displayed-value><stored-value>15164</stored-value></pair>
+      <pair><displayed-value>Stapleton, R.C</displayed-value><stored-value>1148487</stored-value></pair>
+      <pair><displayed-value>Stapleton, Richard</displayed-value><stored-value>358985</stored-value></pair>
+      <pair><displayed-value>Starbuck, William H.</displayed-value><stored-value>345906</stored-value></pair>
+      <pair><displayed-value>Starks, Laura T.</displayed-value><stored-value>17269</stored-value></pair>
+      <pair><displayed-value>Stavins, Robert N.</displayed-value><stored-value>26285</stored-value></pair>
+
+      <pair><displayed-value>Steckel, Joel</displayed-value><stored-value>1749</stored-value></pair>
+      <pair><displayed-value>Steenbeek, Onno W.</displayed-value><stored-value>12019</stored-value></pair>
+      <pair><displayed-value>Stein, Jeremy C.</displayed-value><stored-value>17459</stored-value></pair>
+      <pair><displayed-value>Stein, Roger M.</displayed-value><stored-value>1133983</stored-value></pair>
+      <pair><displayed-value>Steindel, Charles</displayed-value><stored-value>335739</stored-value></pair>
+      <pair><displayed-value>Stiglitz, Joseph E.</displayed-value><stored-value>292740</stored-value></pair>
+
+      <pair><displayed-value>Stohr, Edward</displayed-value><stored-value>1141313</stored-value></pair>
+      <pair><displayed-value>Stohr, Edward A.</displayed-value><stored-value>1133779</stored-value></pair>
+      <pair><displayed-value>Storeletten, Kjetil</displayed-value><stored-value>1132680</stored-value></pair>
+      <pair><displayed-value>Storeslettenand, Kjetil</displayed-value><stored-value>1154635</stored-value></pair>
+      <pair><displayed-value>Stover, Roger D.</displayed-value><stored-value>52304</stored-value></pair>
+      <pair><displayed-value>Strahan, Philip E.</displayed-value><stored-value>16357</stored-value></pair>
+
+      <pair><displayed-value>Streeter, Lynn A.</displayed-value><stored-value>1135977</stored-value></pair>
+      <pair><displayed-value>Strelcova, Jelena</displayed-value><stored-value>1133327</stored-value></pair>
+      <pair><displayed-value>Stremme, Alexander</displayed-value><stored-value>138712</stored-value></pair>
+      <pair><displayed-value>Stroughair, John</displayed-value><stored-value>143390</stored-value></pair>
+      <pair><displayed-value>Struis, Corine</displayed-value><stored-value>397391</stored-value></pair>
+      <pair><displayed-value>Strulovici, Bruno H.</displayed-value><stored-value>405596</stored-value></pair>
+
+      <pair><displayed-value>Stuart, Harborne (Gus) W.</displayed-value><stored-value>266287</stored-value></pair>
+      <pair><displayed-value>Stuchfield, Nic</displayed-value><stored-value>1141337</stored-value></pair>
+      <pair><displayed-value>Stulz, Rene M.</displayed-value><stored-value>17753</stored-value></pair>
+      <pair><displayed-value>Su, Meng</displayed-value><stored-value>996915</stored-value></pair>
+      <pair><displayed-value>Submitter, Banco de Espana Research Paper</displayed-value><stored-value>613124</stored-value></pair>
+      <pair><displayed-value>Submitter, Boston U School of Managment</displayed-value><stored-value>1150988</stored-value></pair>
+
+      <pair><displayed-value>Submitter, CESifo</displayed-value><stored-value>459177</stored-value></pair>
+      <pair><displayed-value>Submitter, IESE</displayed-value><stored-value>361123</stored-value></pair>
+      <pair><displayed-value>Submitter, INSEAD Research Paper Series</displayed-value><stored-value>865831</stored-value></pair>
+      <pair><displayed-value>Submitter, Reg-Markets</displayed-value><stored-value>344990</stored-value></pair>
+      <pair><displayed-value>Submitter, Rock Center</displayed-value><stored-value>1199479</stored-value></pair>
+      <pair><displayed-value>Submitter, Stanford GSB</displayed-value><stored-value>363555</stored-value></pair>
+
+      <pair><displayed-value>Subrahmanyam, Marti G.</displayed-value><stored-value>738</stored-value></pair>
+      <pair><displayed-value>Subramanian, Krishnamurthy</displayed-value><stored-value>114749</stored-value></pair>
+      <pair><displayed-value>Sudhir, K</displayed-value><stored-value>106058</stored-value></pair>
+      <pair><displayed-value>Suggitt, Heather J.</displayed-value><stored-value>62509</stored-value></pair>
+      <pair><displayed-value>Sun, Baohong</displayed-value><stored-value>328069</stored-value></pair>
+      <pair><displayed-value>Sun, Zheng</displayed-value><stored-value>451407</stored-value></pair>
+
+      <pair><displayed-value>Sundaram, Rangarajan K.</displayed-value><stored-value>58699</stored-value></pair>
+      <pair><displayed-value>Sundararajan, Arun</displayed-value><stored-value>21042</stored-value></pair>
+      <pair><displayed-value>Sunder, Shyam</displayed-value><stored-value>160390</stored-value></pair>
+      <pair><displayed-value>Sunder, Shyam Vallabhajosyula</displayed-value><stored-value>332913</stored-value></pair>
+      <pair><displayed-value>Sundgren, S.</displayed-value><stored-value>1151909</stored-value></pair>
+      <pair><displayed-value>Suo, Wulin</displayed-value><stored-value>97747</stored-value></pair>
+
+      <pair><displayed-value>Swait, Joffre</displayed-value><stored-value>59</stored-value></pair>
+      <pair><displayed-value>Swan, Peter Lawrence</displayed-value><stored-value>136389</stored-value></pair>
+      <pair><displayed-value>Swary, Itzhak</displayed-value><stored-value>1152402</stored-value></pair>
+      <pair><displayed-value>Sweeney, James L.</displayed-value><stored-value>21014</stored-value></pair>
+      <pair><displayed-value>Swope, Matthew</displayed-value><stored-value>1133339</stored-value></pair>
+      <pair><displayed-value>Syam, Niladri B.</displayed-value><stored-value>328050</stored-value></pair>
+
+      <pair><displayed-value>Syverson, Chad</displayed-value><stored-value>342888</stored-value></pair>
+      <pair><displayed-value>Szabo, Gabor</displayed-value><stored-value>1149670</stored-value></pair>
+      <pair><displayed-value>Szczesny, Chiara</displayed-value><stored-value>596155</stored-value></pair>
+      <pair><displayed-value>S¬∏lzle, Kai</displayed-value><stored-value>327899</stored-value></pair>
+      <pair><displayed-value>Taliaferro, Ryan</displayed-value><stored-value>400915</stored-value></pair>
+      <pair><displayed-value>Tan, Sinan</displayed-value><stored-value>337586</stored-value></pair>
+
+      <pair><displayed-value>Tan, Sinan</displayed-value><stored-value>780139</stored-value></pair>
+      <pair><displayed-value>Tang, Yi</displayed-value><stored-value>481381</stored-value></pair>
+      <pair><displayed-value>Tanniru, Mohan R.</displayed-value><stored-value>1143356</stored-value></pair>
+      <pair><displayed-value>Tashjian, Richard</displayed-value><stored-value>1147170</stored-value></pair>
+      <pair><displayed-value>Tasley, Roberta</displayed-value><stored-value>1143324</stored-value></pair>
+      <pair><displayed-value>Tawfik Jelassi, Mohamed</displayed-value><stored-value>1143316</stored-value></pair>
+
+      <pair><displayed-value>Tay, Anothony S.</displayed-value><stored-value>1152396</stored-value></pair>
+      <pair><displayed-value>Tay, Anthony S.</displayed-value><stored-value>145355</stored-value></pair>
+      <pair><displayed-value>Taylor, Scott R.</displayed-value><stored-value>1132236</stored-value></pair>
+      <pair><displayed-value>Tchistyi, Alexei</displayed-value><stored-value>468734</stored-value></pair>
+      <pair><displayed-value>Teall, John L.</displayed-value><stored-value>88620</stored-value></pair>
+      <pair><displayed-value>Teece, David J.</displayed-value><stored-value>209629</stored-value></pair>
+
+      <pair><displayed-value>Tehranian, Hassan</displayed-value><stored-value>15851</stored-value></pair>
+      <pair><displayed-value>Telang, Rahul</displayed-value><stored-value>264190</stored-value></pair>
+      <pair><displayed-value>Tellis, Gerard J.</displayed-value><stored-value>117251</stored-value></pair>
+      <pair><displayed-value>Telmer, Chris</displayed-value><stored-value>1151298</stored-value></pair>
+      <pair><displayed-value>Telmer, Christopher I.</displayed-value><stored-value>81288</stored-value></pair>
+      <pair><displayed-value>Teoman, Tuygan</displayed-value><stored-value>1133336</stored-value></pair>
+
+      <pair><displayed-value>Tepla, Lucie</displayed-value><stored-value>303081</stored-value></pair>
+      <pair><displayed-value>Theisen, Mary Beth</displayed-value><stored-value>1142063</stored-value></pair>
+      <pair><displayed-value>Thesmar, David</displayed-value><stored-value>328030</stored-value></pair>
+      <pair><displayed-value>Thomas, Jacquelyn</displayed-value><stored-value>106065</stored-value></pair>
+      <pair><displayed-value>Thomas, Lee R.</displayed-value><stored-value>236721</stored-value></pair>
+      <pair><displayed-value>Thomas, Manoj</displayed-value><stored-value>663904</stored-value></pair>
+
+      <pair><displayed-value>Thomas III, Lee R.</displayed-value><stored-value>1147625</stored-value></pair>
+      <pair><displayed-value>Thuering, Manfred</displayed-value><stored-value>1135972</stored-value></pair>
+      <pair><displayed-value>Timmer, Jens</displayed-value><stored-value>1133787</stored-value></pair>
+      <pair><displayed-value>Tinkelman, Daniel</displayed-value><stored-value>230947</stored-value></pair>
+      <pair><displayed-value>Titman, Sheridan</displayed-value><stored-value>15836</stored-value></pair>
+      <pair><displayed-value>Toussaint-Comeau, Maude</displayed-value><stored-value>343136</stored-value></pair>
+
+      <pair><displayed-value>Touzi, Nizar</displayed-value><stored-value>101146</stored-value></pair>
+      <pair><displayed-value>Touzi, Nizar</displayed-value><stored-value>140257</stored-value></pair>
+      <pair><displayed-value>Trietsch, Dan</displayed-value><stored-value>1142960</stored-value></pair>
+      <pair><displayed-value>Trigeorgis, Lenos</displayed-value><stored-value>33458</stored-value></pair>
+      <pair><displayed-value>Trigueros, Joaguin R.</displayed-value><stored-value>1152398</stored-value></pair>
+      <pair><displayed-value>Trimbath, Susanne</displayed-value><stored-value>272819</stored-value></pair>
+
+      <pair><displayed-value>Trombley, Mark A.</displayed-value><stored-value>16046</stored-value></pair>
+      <pair><displayed-value>Truman, Gregory E.</displayed-value><stored-value>1135961</stored-value></pair>
+      <pair><displayed-value>Trzcinka, Charles</displayed-value><stored-value>16076</stored-value></pair>
+      <pair><displayed-value>Tsai, Janice</displayed-value><stored-value>703063</stored-value></pair>
+      <pair><displayed-value>Tsai, Chih-Ling</displayed-value><stored-value>1283</stored-value></pair>
+      <pair><displayed-value>Tsechansky, Maytal</displayed-value><stored-value>1141323</stored-value></pair>
+
+      <pair><displayed-value>Tsui, Judy S.L.</displayed-value><stored-value>62753</stored-value></pair>
+      <pair><displayed-value>Tucker, Catherine</displayed-value><stored-value>512675</stored-value></pair>
+      <pair><displayed-value>Tucker, Jenny</displayed-value><stored-value>393576</stored-value></pair>
+      <pair><displayed-value>Tucker, X. Jenny</displayed-value><stored-value>1131966</stored-value></pair>
+      <pair><displayed-value>Tumarkin, Robert</displayed-value><stored-value>278008</stored-value></pair>
+      <pair><displayed-value>Tunca, Tunay Ihsan</displayed-value><stored-value>253558</stored-value></pair>
+
+      <pair><displayed-value>Turner, Jon</displayed-value><stored-value>475355</stored-value></pair>
+      <pair><displayed-value>Tuzhilin, Alexander</displayed-value><stored-value>1131950</stored-value></pair>
+      <pair><displayed-value>Tyson, Laura D'Andrea</displayed-value><stored-value>21995</stored-value></pair>
+      <pair><displayed-value>T√Çg, Joacim</displayed-value><stored-value>397712</stored-value></pair>
+      <pair><displayed-value>Udell, Gregory F.</displayed-value><stored-value>43802</stored-value></pair>
+      <pair><displayed-value>Uhlig, Harald</displayed-value><stored-value>56541</stored-value></pair>
+
+      <pair><displayed-value>Ulkumen, Gulden</displayed-value><stored-value>712128</stored-value></pair>
+      <pair><displayed-value>Umapathy, Karthikeyan</displayed-value><stored-value>554694</stored-value></pair>
+      <pair><displayed-value>Umyarov, Akhmed</displayed-value><stored-value>1131963</stored-value></pair>
+      <pair><displayed-value>Uno, Jun</displayed-value><stored-value>131769</stored-value></pair>
+      <pair><displayed-value>Uretsky, Myron</displayed-value><stored-value>475365</stored-value></pair>
+      <pair><displayed-value>Vaaste, Emmanuelle</displayed-value><stored-value>1131953</stored-value></pair>
+
+      <pair><displayed-value>Valkonen, Sami</displayed-value><stored-value>608393</stored-value></pair>
+      <pair><displayed-value>Van Alstyne, Marshall W.</displayed-value><stored-value>253298</stored-value></pair>
+      <pair><displayed-value>Van Cayseele, Patrick J.G.</displayed-value><stored-value>169428</stored-value></pair>
+      <pair><displayed-value>Van Nieuwerburgh, Stijn</displayed-value><stored-value>347304</stored-value></pair>
+      <pair><displayed-value>Van Zandt, Timothy</displayed-value><stored-value>1070023</stored-value></pair>
+      <pair><displayed-value>Vanderhoof, Irwin</displayed-value><stored-value>1152393</stored-value></pair>
+
+      <pair><displayed-value>Vareda, Jo‚Äûo</displayed-value><stored-value>659275</stored-value></pair>
+      <pair><displayed-value>Vargas, Patrick</displayed-value><stored-value>713441</stored-value></pair>
+      <pair><displayed-value>Varian, Hal R.</displayed-value><stored-value>93838</stored-value></pair>
+      <pair><displayed-value>Vassiliou, Yannis</displayed-value><stored-value>1143314</stored-value></pair>
+      <pair><displayed-value>Vayanos, Dimitri</displayed-value><stored-value>15722</stored-value></pair>
+      <pair><displayed-value>Veim, Joan C.</displayed-value><stored-value>1143346</stored-value></pair>
+
+      <pair><displayed-value>Velasco, Andres</displayed-value><stored-value>1154640</stored-value></pair>
+      <pair><displayed-value>Veldkamp, Laura</displayed-value><stored-value>335664</stored-value></pair>
+      <pair><displayed-value>Velucchi, Margherita</displayed-value><stored-value>819458</stored-value></pair>
+      <pair><displayed-value>Verdasca, Andrew</displayed-value><stored-value>681944</stored-value></pair>
+      <pair><displayed-value>Verdelhan, Adrien</displayed-value><stored-value>368958</stored-value></pair>
+      <pair><displayed-value>Verdier, Thierry</displayed-value><stored-value>43780</stored-value></pair>
+
+      <pair><displayed-value>Veredas, David</displayed-value><stored-value>334702</stored-value></pair>
+      <pair><displayed-value>Verykios, Vassilios</displayed-value><stored-value>1131959</stored-value></pair>
+      <pair><displayed-value>Vessey, Iris</displayed-value><stored-value>898554</stored-value></pair>
+      <pair><displayed-value>Viard, Brian</displayed-value><stored-value>1146522</stored-value></pair>
+      <pair><displayed-value>Viard, V. Brian</displayed-value><stored-value>329487</stored-value></pair>
+      <pair><displayed-value>Viard, V. Brian</displayed-value><stored-value>1133342</stored-value></pair>
+
+      <pair><displayed-value>Viard, V.Brian</displayed-value><stored-value>1132679</stored-value></pair>
+      <pair><displayed-value>Viard (Stanford), V. Brian</displayed-value><stored-value>1133344</stored-value></pair>
+      <pair><displayed-value>Vigneron, Olivier</displayed-value><stored-value>379820</stored-value></pair>
+      <pair><displayed-value>Vilarrubia, Josep M.</displayed-value><stored-value>522412</stored-value></pair>
+      <pair><displayed-value>Villanueva, Julian</displayed-value><stored-value>112700</stored-value></pair>
+      <pair><displayed-value>Vinod, Hrishikesh D.</displayed-value><stored-value>139267</stored-value></pair>
+
+      <pair><displayed-value>Violante, Giovanni</displayed-value><stored-value>35267</stored-value></pair>
+      <pair><displayed-value>Viscusi, W. Kip</displayed-value><stored-value>84668</stored-value></pair>
+      <pair><displayed-value>Vissing-Jorgensen, Annette</displayed-value><stored-value>252314</stored-value></pair>
+      <pair><displayed-value>Viswanathan, Siva</displayed-value><stored-value>340684</stored-value></pair>
+      <pair><displayed-value>Viswanathan, Sivakumar</displayed-value><stored-value>1133777</stored-value></pair>
+      <pair><displayed-value>Vogt, William B.</displayed-value><stored-value>83175</stored-value></pair>
+
+      <pair><displayed-value>Volinsky, Chris</displayed-value><stored-value>1131954</stored-value></pair>
+      <pair><displayed-value>Voronov, Artem B.</displayed-value><stored-value>540845</stored-value></pair>
+      <pair><displayed-value>Vulcano, Gustavo</displayed-value><stored-value>936341</stored-value></pair>
+      <pair><displayed-value>Wachtel, Paul</displayed-value><stored-value>17656</stored-value></pair>
+      <pair><displayed-value>Wachter, Jessica A.</displayed-value><stored-value>159310</stored-value></pair>
+      <pair><displayed-value>Wallace, Nancy E.</displayed-value><stored-value>15166</stored-value></pair>
+
+      <pair><displayed-value>Wallsten, Scott</displayed-value><stored-value>203971</stored-value></pair>
+      <pair><displayed-value>Walter, Ingo</displayed-value><stored-value>17591</stored-value></pair>
+      <pair><displayed-value>Walton, Eric J.</displayed-value><stored-value>1142958</stored-value></pair>
+      <pair><displayed-value>Wang, Cheng</displayed-value><stored-value>263888</stored-value></pair>
+      <pair><displayed-value>Wang, Jiang</displayed-value><stored-value>17464</stored-value></pair>
+      <pair><displayed-value>Wang, Junmin</displayed-value><stored-value>690607</stored-value></pair>
+
+      <pair><displayed-value>Wang, Yi</displayed-value><stored-value>720818</stored-value></pair>
+      <pair><displayed-value>Wang, Yu-Ming</displayed-value><stored-value>1135985</stored-value></pair>
+      <pair><displayed-value>Ward, Michael Robert</displayed-value><stored-value>245196</stored-value></pair>
+      <pair><displayed-value>Warneryd, Karl</displayed-value><stored-value>75848</stored-value></pair>
+      <pair><displayed-value>Warren, David S.</displayed-value><stored-value>1143424</stored-value></pair>
+      <pair><displayed-value>Watanabe, Masahiro</displayed-value><stored-value>224204</stored-value></pair>
+
+      <pair><displayed-value>Weber, Bruce</displayed-value><stored-value>412896</stored-value></pair>
+      <pair><displayed-value>Weber, Ron</displayed-value><stored-value>1143344</stored-value></pair>
+      <pair><displayed-value>Wei, Chenyang</displayed-value><stored-value>108742</stored-value></pair>
+      <pair><displayed-value>Wei, Kelsey D.</displayed-value><stored-value>651866</stored-value></pair>
+      <pair><displayed-value>Wei Tang, Vicki</displayed-value><stored-value>1145078</stored-value></pair>
+      <pair><displayed-value>Weidenbaum, Murray</displayed-value><stored-value>239680</stored-value></pair>
+
+      <pair><displayed-value>Weigend, Andreas</displayed-value><stored-value>1510</stored-value></pair>
+      <pair><displayed-value>Weill, Peter</displayed-value><stored-value>327559</stored-value></pair>
+      <pair><displayed-value>Weill, Pierre-Olivier</displayed-value><stored-value>445145</stored-value></pair>
+      <pair><displayed-value>Weinberg, Stephen Ernest</displayed-value><stored-value>330164</stored-value></pair>
+      <pair><displayed-value>Weinstein, David E.</displayed-value><stored-value>17080</stored-value></pair>
+      <pair><displayed-value>Weintraub, Gabriel Y.</displayed-value><stored-value>739931</stored-value></pair>
+
+      <pair><displayed-value>Weintrop, Joseph</displayed-value><stored-value>27290</stored-value></pair>
+      <pair><displayed-value>Weisbach, Michael S.</displayed-value><stored-value>1641</stored-value></pair>
+      <pair><displayed-value>Weisman, Dennis</displayed-value><stored-value>71717</stored-value></pair>
+      <pair><displayed-value>Weiss, Elliot</displayed-value><stored-value>1133346</stored-value></pair>
+      <pair><displayed-value>Weiss, Lawrence A.</displayed-value><stored-value>21433</stored-value></pair>
+      <pair><displayed-value>Weitz, Rob R.</displayed-value><stored-value>1141312</stored-value></pair>
+
+      <pair><displayed-value>Wen, Zhong</displayed-value><stored-value>482952</stored-value></pair>
+      <pair><displayed-value>Werker, Bas J.M.</displayed-value><stored-value>50141</stored-value></pair>
+      <pair><displayed-value>Weston, J. Fred</displayed-value><stored-value>16231</stored-value></pair>
+      <pair><displayed-value>White, Alan</displayed-value><stored-value>296747</stored-value></pair>
+      <pair><displayed-value>White, Larry</displayed-value><stored-value>425827</stored-value></pair>
+      <pair><displayed-value>White, Lawrence J.</displayed-value><stored-value>15117</stored-value></pair>
+
+      <pair><displayed-value>White, Norman</displayed-value><stored-value>475367</stored-value></pair>
+      <pair><displayed-value>Whitelaw, Robert F.</displayed-value><stored-value>42751</stored-value></pair>
+      <pair><displayed-value>Whitson, Jennifer</displayed-value><stored-value>341652</stored-value></pair>
+      <pair><displayed-value>Wiesenfeld, Batia</displayed-value><stored-value>653997</stored-value></pair>
+      <pair><displayed-value>Wiggins, Steven N.</displayed-value><stored-value>535660</stored-value></pair>
+      <pair><displayed-value>Wilde, Christian</displayed-value><stored-value>451705</stored-value></pair>
+
+      <pair><displayed-value>Wildman, Steven S.</displayed-value><stored-value>83528</stored-value></pair>
+      <pair><displayed-value>Wilhelm, William J.</displayed-value><stored-value>15853</stored-value></pair>
+      <pair><displayed-value>Wilhelm Jr., William J.</displayed-value><stored-value>1151902</stored-value></pair>
+      <pair><displayed-value>Wilkinson, Dennis</displayed-value><stored-value>1159559</stored-value></pair>
+      <pair><displayed-value>Williams, Kristen</displayed-value><stored-value>884309</stored-value></pair>
+      <pair><displayed-value>Willig, Robert D.</displayed-value><stored-value>93847</stored-value></pair>
+
+      <pair><displayed-value>Wilson, Barry</displayed-value><stored-value>1154226</stored-value></pair>
+      <pair><displayed-value>Windschitl, Paul D.</displayed-value><stored-value>713433</stored-value></pair>
+      <pair><displayed-value>Winer, Russell</displayed-value><stored-value>333381</stored-value></pair>
+      <pair><displayed-value>Wohl, Avi</displayed-value><stored-value>32069</stored-value></pair>
+      <pair><displayed-value>Wolfenzon, Daniel</displayed-value><stored-value>245571</stored-value></pair>
+      <pair><displayed-value>Wolfers, Justin</displayed-value><stored-value>199369</stored-value></pair>
+
+      <pair><displayed-value>Wolff, Edward N.</displayed-value><stored-value>46052</stored-value></pair>
+      <pair><displayed-value>Wolff, Michael C</displayed-value><stored-value>378439</stored-value></pair>
+      <pair><displayed-value>Wolfram, Catherine D.</displayed-value><stored-value>17351</stored-value></pair>
+      <pair><displayed-value>Woodbury, Linda</displayed-value><stored-value>229587</stored-value></pair>
+      <pair><displayed-value>Working Paper Series, UPF</displayed-value><stored-value>386779</stored-value></pair>
+      <pair><displayed-value>Working Papers, MIT Sloan</displayed-value><stored-value>285952</stored-value></pair>
+
+      <pair><displayed-value>Wright, Charles R.</displayed-value><stored-value>383749</stored-value></pair>
+      <pair><displayed-value>Wright, Charles</displayed-value><stored-value>1143032</stored-value></pair>
+      <pair><displayed-value>Wright, Jonathan H.</displayed-value><stored-value>232682</stored-value></pair>
+      <pair><displayed-value>Wright, Randall D.</displayed-value><stored-value>180440</stored-value></pair>
+      <pair><displayed-value>Wu, D.J.</displayed-value><stored-value>704252</stored-value></pair>
+      <pair><displayed-value>Wu, Guojun</displayed-value><stored-value>107650</stored-value></pair>
+
+      <pair><displayed-value>Wu, Liuren</displayed-value><stored-value>381854</stored-value></pair>
+      <pair><displayed-value>Wu, Min</displayed-value><stored-value>98278</stored-value></pair>
+      <pair><displayed-value>Wulf, Julie M.</displayed-value><stored-value>145988</stored-value></pair>
+      <pair><displayed-value>Wurgler, Je rey</displayed-value><stored-value>1148481</stored-value></pair>
+      <pair><displayed-value>Wurgler, Jeffery</displayed-value><stored-value>1148143</stored-value></pair>
+      <pair><displayed-value>Wurgler, Jeffrey A.</displayed-value><stored-value>174751</stored-value></pair>
+
+      <pair><displayed-value>Xavier, Gabaix</displayed-value><stored-value>1147163</stored-value></pair>
+      <pair><displayed-value>Xiao, Mo</displayed-value><stored-value>114943</stored-value></pair>
+      <pair><displayed-value>Xiao, Xiaohong Anna</displayed-value><stored-value>437190</stored-value></pair>
+      <pair><displayed-value>Xiao, Zhixing</displayed-value><stored-value>691759</stored-value></pair>
+      <pair><displayed-value>Xie, Jinhong</displayed-value><stored-value>328081</stored-value></pair>
+      <pair><displayed-value>Xin, Mingdi</displayed-value><stored-value>550610</stored-value></pair>
+
+      <pair><displayed-value>Xiong, Wei</displayed-value><stored-value>196859</stored-value></pair>
+      <pair><displayed-value>Xitco, Christopher</displayed-value><stored-value>355389</stored-value></pair>
+      <pair><displayed-value>Xu, Yexiao</displayed-value><stored-value>213750</stored-value></pair>
+      <pair><displayed-value>Yaari, Varda Lewinstein</displayed-value><stored-value>32059</stored-value></pair>
+      <pair><displayed-value>Yadav, Pradeep K.</displayed-value><stored-value>141758</stored-value></pair>
+      <pair><displayed-value>Yakov, Amihud</displayed-value><stored-value>1151293</stored-value></pair>
+
+      <pair><displayed-value>Yan, Hong</displayed-value><stored-value>282808</stored-value></pair>
+      <pair><displayed-value>Yang, Sha</displayed-value><stored-value>885119</stored-value></pair>
+      <pair><displayed-value>Yang, Wei</displayed-value><stored-value>366166</stored-value></pair>
+      <pair><displayed-value>Ye, Yinyu</displayed-value><stored-value>364213</stored-value></pair>
+      <pair><displayed-value>Yellen, Janet L.</displayed-value><stored-value>328325</stored-value></pair>
+      <pair><displayed-value>Yen, Benjamin P.-C.</displayed-value><stored-value>1133794</stored-value></pair>
+
+      <pair><displayed-value>Yermack, David</displayed-value><stored-value>44459</stored-value></pair>
+      <pair><displayed-value>Yeung, Bernard Yin</displayed-value><stored-value>71371</stored-value></pair>
+      <pair><displayed-value>Yoffie, David</displayed-value><stored-value>268795</stored-value></pair>
+      <pair><displayed-value>Yorukoglu, Mehmet</displayed-value><stored-value>80710</stored-value></pair>
+      <pair><displayed-value>Yorulmazer, Tanju</displayed-value><stored-value>91471</stored-value></pair>
+      <pair><displayed-value>Yu, George C</displayed-value><stored-value>874066</stored-value></pair>
+
+      <pair><displayed-value>Yu, Lei</displayed-value><stored-value>333354</stored-value></pair>
+      <pair><displayed-value>Yu, Xiaoyun</displayed-value><stored-value>170029</stored-value></pair>
+      <pair><displayed-value>Yuan, Yu</displayed-value><stored-value>533582</stored-value></pair>
+      <pair><displayed-value>Yun, Hayong</displayed-value><stored-value>410573</stored-value></pair>
+      <pair><displayed-value>Yung, Chung</displayed-value><stored-value>1133785</stored-value></pair>
+      <pair><displayed-value>Zach, Tzachi</displayed-value><stored-value>197470</stored-value></pair>
+
+      <pair><displayed-value>Zacharias, Josh</displayed-value><stored-value>1146530</stored-value></pair>
+      <pair><displayed-value>Zacharias, Joshua</displayed-value><stored-value>1133321</stored-value></pair>
+      <pair><displayed-value>Zajonc, Peter C.</displayed-value><stored-value>1142085</stored-value></pair>
+      <pair><displayed-value>Zand, Dale E.</displayed-value><stored-value>354026</stored-value></pair>
+      <pair><displayed-value>Zarowin, Paul</displayed-value><stored-value>17664</stored-value></pair>
+      <pair><displayed-value>Zeckhauser, Richard J.</displayed-value><stored-value>17140</stored-value></pair>
+
+      <pair><displayed-value>Zeithammer, Robert</displayed-value><stored-value>333679</stored-value></pair>
+      <pair><displayed-value>Zemel, Dr. Eitan</displayed-value><stored-value>1147154</stored-value></pair>
+      <pair><displayed-value>Zemel, Eitan</displayed-value><stored-value>1143352</stored-value></pair>
+      <pair><displayed-value>Zemsky, Peter B.</displayed-value><stored-value>21599</stored-value></pair>
+      <pair><displayed-value>Zeng, Qi</displayed-value><stored-value>463465</stored-value></pair>
+      <pair><displayed-value>Zghaibeh, Manaf</displayed-value><stored-value>701848</stored-value></pair>
+
+      <pair><displayed-value>Zhang, Jiawei</displayed-value><stored-value>1147156</stored-value></pair>
+      <pair><displayed-value>Zhang, Jie Jennifer</displayed-value><stored-value>283009</stored-value></pair>
+      <pair><displayed-value>Zhang, Jin E.</displayed-value><stored-value>115795</stored-value></pair>
+      <pair><displayed-value>Zhang, Xiaoquan (Michael)</displayed-value><stored-value>102553</stored-value></pair>
+      <pair><displayed-value>Zhang, Z. John</displayed-value><stored-value>994223</stored-value></pair>
+      <pair><displayed-value>Zhao, J. Leon</displayed-value><stored-value>1133782</stored-value></pair>
+
+      <pair><displayed-value>Zhao, Minyuan</displayed-value><stored-value>565026</stored-value></pair>
+      <pair><displayed-value>Zheng, Rong</displayed-value><stored-value>853994</stored-value></pair>
+      <pair><displayed-value>Zhou, Chunsheng</displayed-value><stored-value>15811</stored-value></pair>
+      <pair><displayed-value>Zhou, Mingming</displayed-value><stored-value>441320</stored-value></pair>
+      <pair><displayed-value>Zhou, Nan</displayed-value><stored-value>44843</stored-value></pair>
+      <pair><displayed-value>Zhou, Yan</displayed-value><stored-value>884393</stored-value></pair>
+
+      <pair><displayed-value>Zhu, Feng</displayed-value><stored-value>400098</stored-value></pair>
+      <pair><displayed-value>Zin, Stanley E.</displayed-value><stored-value>51622</stored-value></pair>
+      <pair><displayed-value>Zin, Stanley E.</displayed-value><stored-value>371011</stored-value></pair>
+      <pair><displayed-value>Zumbansen, Peer</displayed-value><stored-value>109516</stored-value></pair>
+      <pair><displayed-value>Zur, Emanuel</displayed-value><stored-value>424195</stored-value></pair>
+      <pair><displayed-value>Zweig, Dani</displayed-value><stored-value>1135986</stored-value></pair>
+
+      <pair><displayed-value>and Portfolio Management, Financial Markets</displayed-value><stored-value>510373</stored-value></pair>
+      <pair><displayed-value>chassagnon, virgile</displayed-value><stored-value>925887</stored-value></pair>
+      <pair><displayed-value>de Castro, Rui Lu√ås</displayed-value><stored-value>334015</stored-value></pair>
+      <pair><displayed-value>de Mesquita, Bruce Bueno</displayed-value><stored-value>1144332</stored-value></pair>
+      <pair><displayed-value>de Vaujany, Francois-Xavier</displayed-value><stored-value>1185598</stored-value></pair>
+      <pair><displayed-value>jain, pranay</displayed-value><stored-value>1033091</stored-value></pair>
+
+      <pair><displayed-value>krasny, yoel</displayed-value><stored-value>655513</stored-value></pair>
+      <pair><displayed-value>lchiishi, Tatsuro</displayed-value><stored-value>1141319</stored-value></pair>
+      <pair><displayed-value>lgbaria, Magid</displayed-value><stored-value>1142061</stored-value></pair>
+      <pair><displayed-value>lord, graham</displayed-value><stored-value>1014496</stored-value></pair>
+      <pair><displayed-value>lsakowitz, Tomas</displayed-value><stored-value>1135953</stored-value></pair>
+      <pair><displayed-value>ma, lan</displayed-value><stored-value>925927</stored-value></pair>
+
+      <pair><displayed-value>mccabe, jennifer c</displayed-value><stored-value>1084831</stored-value></pair>
+      <pair><displayed-value>murphy, frederic</displayed-value><stored-value>577407</stored-value></pair>
+      <pair><displayed-value>nichols, william d</displayed-value><stored-value>578670</stored-value></pair>
+      <pair><displayed-value>nye, richard b</displayed-value><stored-value>461932</stored-value></pair>
+      <pair><displayed-value>of Poland, National Bank</displayed-value><stored-value>851390</stored-value></pair>
+      <pair><displayed-value>sokoler, meir h</displayed-value><stored-value>1090155</stored-value></pair>
+
+      <pair><displayed-value>van Binsbergen, Jules H.</displayed-value><stored-value>545907</stored-value></pair>
+      <pair><displayed-value>van Heck, Eric</displayed-value><stored-value>338963</stored-value></pair>
+      <pair><displayed-value>van Hemert, Otto</displayed-value><stored-value>346474</stored-value></pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="lila_days" dc-term="relations">
+      <pair>
+        <displayed-value>N/A</displayed-value>
+        <stored-value>N/A</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day1</displayed-value>
+        <stored-value>Day1</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day2</displayed-value>
+        <stored-value>Day2</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day3</displayed-value>
+        <stored-value>Day3</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day4</displayed-value>
+        <stored-value>Day4</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day5</displayed-value>
+        <stored-value>Day5</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day6</displayed-value>
+        <stored-value>Day6</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day7</displayed-value>
+        <stored-value>Day7</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day8</displayed-value>
+        <stored-value>Day8</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day9</displayed-value>
+        <stored-value>Day9</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day10</displayed-value>
+        <stored-value>Day10</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day11</displayed-value>
+        <stored-value>Day11</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day12</displayed-value>
+        <stored-value>Day12</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day13</displayed-value>
+        <stored-value>Day13</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day14</displayed-value>
+        <stored-value>Day14</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day15</displayed-value>
+        <stored-value>Day15</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day16</displayed-value>
+        <stored-value>Day16</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day17</displayed-value>
+        <stored-value>Day17</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day18</displayed-value>
+        <stored-value>Day18</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day19</displayed-value>
+        <stored-value>Day19</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day20</displayed-value>
+        <stored-value>Day20</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day21</displayed-value>
+        <stored-value>Day21</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day22</displayed-value>
+        <stored-value>Day22</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day23</displayed-value>
+        <stored-value>Day23</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day24</displayed-value>
+        <stored-value>Day24</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day25</displayed-value>
+        <stored-value>Day25</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day26</displayed-value>
+        <stored-value>Day26</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day27</displayed-value>
+        <stored-value>Day27</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day28</displayed-value>
+        <stored-value>Day28</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day29</displayed-value>
+        <stored-value>Day29</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day30</displayed-value>
+        <stored-value>Day30</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Day31</displayed-value>
+        <stored-value>Day31</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="gallatin_subjects" dc-term="topic">
+      <pair>
+        <displayed-value>ARTS-UG</displayed-value>
+        <stored-value>ARTS-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>CLI-UG</displayed-value>
+        <stored-value>CLI-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>CORE-GG</displayed-value>
+        <stored-value>CORE-GG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>ELEC-GG</displayed-value>
+        <stored-value>ELEC-GG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>FIRST-UG</displayed-value>
+        <stored-value>FIRST-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>IDSEM-UG</displayed-value>
+        <stored-value>IDSEM-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>PRACT-UG</displayed-value>
+        <stored-value>PRACT-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>TRAVL-UG</displayed-value>
+        <stored-value>TRAVL-UG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>TRAVL-GG</displayed-value>
+        <stored-value>TRAVL-GG</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>WRTNG-UG</displayed-value>
+        <stored-value>WRTNG-UG</stored-value>
+      </pair>
+    </value-pairs>
+    <value-pairs value-pairs-name="jones_languages" dc-term="language_iso">
+      <pair>
         <displayed-value>Greek, Ancient (to 1453)</displayed-value>
         <stored-value>grc</stored-value>
-       </pair>
-       <pair>
+      </pair>
+      <pair>
         <displayed-value>Oscan</displayed-value>
         <stored-value>osc</stored-value>
-       </pair>
-      <pair>
-       <displayed-value>Egyptian, Ancient</displayed-value>
-       <stored-value>egy</stored-value>
       </pair>
       <pair>
-       <displayed-value>Akkadian</displayed-value>
-       <stored-value>akk</stored-value>
+        <displayed-value>Egyptian, Ancient</displayed-value>
+        <stored-value>egy</stored-value>
       </pair>
       <pair>
-       <displayed-value>Latin</displayed-value>
-       <stored-value>lat</stored-value>
+        <displayed-value>Akkadian</displayed-value>
+        <stored-value>akk</stored-value>
       </pair>
       <pair>
-       <displayed-value>None</displayed-value>
-       <stored-value>none</stored-value>
+        <displayed-value>Latin</displayed-value>
+        <stored-value>lat</stored-value>
       </pair>
-   </value-pairs>
-</form-value-pairs>
+      <pair>
+        <displayed-value>None</displayed-value>
+        <stored-value>none</stored-value>
+      </pair>
+    </value-pairs>
+  </form-value-pairs>
 </input-forms>
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -19,6 +19,20 @@
  <submission-map>
    <name-map collection-handle="default"    submission-name="traditional" />
    <name-map collection-handle="2451/34841" submission-name="gallatin"    />
+
+   <name-map collection-handle="2451/28318" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/28320" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29655" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29656" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29658" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29659" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29676" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29898" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/29947" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/33605" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/34304" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/34305" submission-name="rights-entry-on-dmd-form" />
+   <name-map collection-handle="2451/42113" submission-name="rights-entry-on-dmd-form" />
  </submission-map>
 
 
@@ -178,6 +192,49 @@
 
      <!--This "traditional" process defines the DEFAULT item submission process-->
      <submission-process name="traditional">
+         <step>
+             <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
+         </step>
+         <step>
+             <heading>submit.progressbar.license</heading>
+             <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
+             <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
+             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
+             <workflow-editable>false</workflow-editable>
+         </step>
+         <step>
+             <heading>submit.progressbar.upload</heading>
+             <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
+             <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
+             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+             <workflow-editable>true</workflow-editable>
+         </step>
+         <step>
+             <heading>submit.progressbar.describe</heading>
+             <processing-class>org.dspace.submit.step.DescribeStep</processing-class>
+             <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeStep</jspui-binding>
+             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
+             <workflow-editable>true</workflow-editable>
+         </step>
+         <step>
+             <heading>submit.progressbar.access</heading>
+             <processing-class>org.dspace.submit.step.AccessStep</processing-class>
+             <jspui-binding>org.dspace.app.webui.submit.step.JSPAccessStep</jspui-binding>
+             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.AccessStep</xmlui-binding>
+             <workflow-editable>true</workflow-editable>
+         </step>
+         <step>
+             <heading>submit.progressbar.verify</heading>
+             <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
+             <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
+             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
+             <workflow-editable>true</workflow-editable>
+         </step>
+     </submission-process>
+
+     <!-- This submission process uses a DMD form that includes rights entry   -->
+     <!-- instead of having rights entry as a separate step          -->
+     <submission-process name="rights-entry-on-dmd-form">
          <step>
              <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
          </step>

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -3,72 +3,70 @@
 
 <!-- Configurable Submission configuration file  -->
 
-<!-- This XML configuration file allows you to configure the ordering     -->
-<!-- and number of the steps that occur in the Item Submission Process.   -->
+<!-- This XML configuration file allows you to configure the ordering        -->
+<!-- and number of the steps that occur in the Item Submission Process.      -->
 <item-submission>
 
- <!-- The process-map maps collection handles to a particular Item         -->
- <!-- Submission Process.  This requires that a collection's name be       -->
- <!-- unique, even within a community. DSpace does however ensure that each-->
- <!-- collection's handle is unique.  Process-map provides the means to    -->
- <!-- associate a unique collection name with an Item Submission process.  -->
- <!-- The process-map also provides the special handle "default" (which is -->
- <!-- never a collection), here mapped to "traditional". Any collection    -->
- <!-- which does not appear in this map will be associated with the mapping-->
- <!-- for handle "default".                                                -->
+ <!-- The process-map maps collection handles to a particular Item           -->
+ <!-- Submission Process.  This requires that a collection's name be         -->
+ <!-- unique, even within a community. DSpace does however ensure that each  -->
+ <!-- collection's handle is unique.  Process-map provides the means to      -->
+ <!-- associate a unique collection name with an Item Submission process.    -->
+ <!-- The process-map also provides the special handle "default" (which is   -->
+ <!-- never a collection), here mapped to "traditional". Any collection      -->
+ <!-- which does not appear in this map will be associated with the mapping  -->
+ <!-- for handle "default".                                                  -->
  <submission-map>
-   <name-map collection-handle="default" submission-name="traditional" />
-   <name-map collection-handle="2451/34841" submission-name="gallatin" />
+   <name-map collection-handle="default"    submission-name="traditional" />
+   <name-map collection-handle="2451/34841" submission-name="gallatin"    />
  </submission-map>
 
 
-
-
- <!-- The 'step-definitions' allows you to define steps which you may wish -->
- <!-- to "share" amongst multiple submission-item definitions.  In order to-->
- <!-- share the same step definition, you can refer to it by its unique id -->
- <!-- defined in this section.  EVERY 'step' in this section MUST have a   -->
- <!-- unique identifier in the 'id' attribute!                             -->
- <!--                                                                      -->
- <!-- Each <step> REQUIRES the following attributes (@) and properties:    --> 
- <!-- @id                - The unique identifier for this step             -->
- <!-- 																	   -->
- <!-- <processing-class> - The class which will process all information for-->
- <!--             this step. The class must extend						   -->
- <!--             'org.dspace.submit.AbstractProcessingStep'               -->
- <!--             (or one of the org.dspace.submit.step.* classes)         -->
- <!--             This property should reference the full path of the class-->
- <!--			  (e.g. org.dspace.submit.step.MyCustomStep)               -->
- <!--																	   -->
- <!-- The following properties are OPTIONAL for each <step>:			   -->
- <!-- <heading> -    References the message key, from the 				   -->
- <!--			     Messages.properties file (JSP-UI) or messages.xml     -->
- <!--                (XML-UI) which will be used as this step's heading in -->
- <!--			     the progress-bar.  If unspecified, the step does not  -->
- <!--			     show up in the Progress Bar.  Keys in the <heading>   -->
- <!--				 are prefixed as follows in the appropriate 		   -->
- <!--				 "messages" file:							           -->
- <!--						XML-UI:  "xmlui.Submission." prefix			   -->
- <!--						JSP-UI:  "jsp." prefix			   			   -->
+ <!-- The 'step-definitions' allows you to define steps which you may wish   -->
+ <!-- to "share" amongst multiple submission-item definitions.  In order to  -->
+ <!-- share the same step definition, you can refer to it by its unique id   -->
+ <!-- defined in this section.  EVERY 'step' in this section MUST have a     -->
+ <!-- unique identifier in the 'id' attribute!                               -->
+ <!--                                                                        -->
+ <!-- Each <step> REQUIRES the following attributes (@) and properties:      --> 
+ <!-- @id                - The unique identifier for this step               -->
+ <!--                                                                        -->
+ <!-- <processing-class> - The class which will process all information for  -->
+ <!--             this step. The class must extend                           -->
+ <!--             'org.dspace.submit.AbstractProcessingStep'                 -->
+ <!--             (or one of the org.dspace.submit.step.* classes)           -->
+ <!--             This property should reference the full path of the class  -->
+ <!--              (e.g. org.dspace.submit.step.MyCustomStep)                -->
+ <!--                                                                        -->
+ <!-- The following properties are OPTIONAL for each <step>:                 -->
+ <!-- <heading> -    References the message key, from the                    -->
+ <!--                Messages.properties file (JSP-UI) or messages.xml       -->
+ <!--                (XML-UI) which will be used as this step's heading in   -->
+ <!--                the progress-bar.  If unspecified, the step does not    -->
+ <!--                show up in the Progress Bar.  Keys in the <heading>     -->
+ <!--                are prefixed as follows in the appropriate              -->
+ <!--                "messages" file:                                        -->
+ <!--                  XML-UI:  "xmlui.Submission." prefix                 -->
+ <!--                  JSP-UI:  "jsp." prefix                                -->
  <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
- <!--                 based user interface for this step.  The class must  -->
- <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.        -->
- <!--                 This property should reference the full path of the  -->
- <!--                 class.  It is only necessary if you are using the    -->
- <!--                 DSpace JSP-UI, and the step requires user interaction-->
- <!-- <xmlui-binding> - XML-UI binding step class which will generate the  -->
- <!--                 Manakin XML (DRI) structure for this step.  The class-->
- <!--                 must extend                                          -->
+ <!--                 based user interface for this step.  The class must    -->
+ <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
+ <!--                 This property should reference the full path of the    -->
+ <!--                 class.  It is only necessary if you are using the      -->
+ <!--                 DSpace JSP-UI, and the step requires user interaction  -->
+ <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
+ <!--                 Manakin XML (DRI) structure for this step.  The class  -->
+ <!--                 must extend                                            -->
  <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.-->
- <!--                 This property should reference the full path of the  -->
- <!--                 class.  It is only necessary if you are using the    -->
- <!--                 DSpace XML-UI, and the step requires user interaction-->
- <!-- <workflow-editable> - whether or not this step will appear during the-->
- <!--				 "Edit Metadata" workflow approval process.  This field-->
- <!--				 defaults to TRUE (which means it can be edited during -->
- <!--				 the "Edit Metadata" workflow stage)				   -->
- <!--                                                                      -->
- <!--                                                                      -->
+ <!--                 This property should reference the full path of the    -->
+ <!--                 class.  It is only necessary if you are using the      -->
+ <!--                 DSpace XML-UI, and the step requires user interaction  -->
+ <!-- <workflow-editable> - whether or not this step will appear during the  -->
+ <!--                 "Edit Metadata" workflow approval process.  This field -->
+ <!--                 defaults to TRUE (which means it can be edited during  -->
+ <!--                 the "Edit Metadata" workflow stage)                    -->
+ <!--                                                                        -->
+ <!--                                                                        -->
  <step-definitions>
      <!-- The "collection" step is a "special step" which is *REQUIRED* to be-->
      <!-- in this section!  In DSpace, all submitted items must be           -->
@@ -84,16 +82,16 @@
      <!-- a special step, it is currently NEVER editable in a workflow.      -->                              
      <step id="collection">
        <heading></heading> <!--can specify heading, if you want it to appear in Progress Bar-->
-	   <processing-class>org.dspace.submit.step.SelectCollectionStep</processing-class>
+       <processing-class>org.dspace.submit.step.SelectCollectionStep</processing-class>
        <jspui-binding>org.dspace.app.webui.submit.step.JSPSelectCollectionStep</jspui-binding>
        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
        <workflow-editable>false</workflow-editable>
      </step>
      
-	 <!-- Uncomment this to make available the bibliographic import from external source - note ONLY for JSPUI -->     
-	 <!-- <step id="collection">
+     <!-- Uncomment this to make available the bibliographic import from external source - note ONLY for JSPUI -->     
+     <!-- <step id="collection">
        <heading></heading> can specify heading, if you want it to appear in Progress Bar
-	   <processing-class>org.dspace.submit.step.StartSubmissionLookupStep</processing-class>
+       <processing-class>org.dspace.submit.step.StartSubmissionLookupStep</processing-class>
        <jspui-binding>org.dspace.app.webui.submit.step.JSPStartSubmissionLookupStep</jspui-binding>
        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
        <workflow-editable>false</workflow-editable>
@@ -115,7 +113,7 @@
        <workflow-editable>false</workflow-editable>
      </step>
    
-     <!-- This is the Sample Step which utilizes the JSPSampleStep class-->
+     <!-- This is the Sample Step which utilizes the JSPSampleStep class -->
      <step id="sample">
        <heading>Sample</heading>
        <processing-class>org.dspace.submit.step.SampleStep</processing-class>
@@ -124,58 +122,58 @@
      </step>
  </step-definitions>
 
- <!-- The submission-definitions map lays out the detailed definition of   -->
- <!-- all the Item Submission Processes (and the ordering of their steps). -->
- <!-- Each separate "submission-process" has a unique name as an attribute,-->
- <!-- which matches one of the names in the process-map. One named         -->
- <!-- "submit-process" has the name "traditional"; as this name suggests,  -->
- <!-- it is the default item submission process, which gets used when      -->
- <!-- the specified collection has no correspondingly named submit-process.-->
- <!--                                                                      -->
- <!-- Each submit-process contains an ordered set of steps; each step      -->
- <!-- defines one "step" occurring during the process of submitting an     -->
- <!-- item.  A step can either be referenced by 'id' (in which case it must-->
- <!-- be defined in <step-definitions> above), or defined completely here. -->
- <!--                                                                      -->
- <!-- If the step is not referred to by 'id', then the <step> REQUIRES the -->
- <!-- following properties are defined:                                    --> 
- <!-- <processing-class> - The class which will process all information for-->
- <!--             this step. The class must implement the                  -->
- <!--             'org.dspace.app.webui.submit.JSPStep' interface AND      -->
- <!--             extend 'org.dspace.submit.AbstractProcessingStep'        -->
- <!--             (or one of the org.dspace.submit.step.* classes)         -->
- <!--             This property should reference the full path of the class-->
- <!--			  (e.g. org.dspace.app.webui.submit.MyCustomJSPStep)       -->
- <!--                                                                      -->
- <!-- The following properties are OPTIONAL for each <step>:			   -->
- <!-- <heading> -    References the message key, from the 				   -->
- <!--			     Messages.properties file (JSP-UI) or messages.xml     -->
- <!--                (XML-UI) which will be used as this step's heading in -->
- <!--			     the progress-bar.  If unspecified, the step does not  -->
- <!--			     show up in the Progress Bar.  Keys in the <heading>   -->
- <!--				 are prefixed as follows in the appropriate 		   -->
- <!--				 "messages" file:							           -->
- <!--						XML-UI:  "xmlui.Submission." prefix			   -->
- <!--						JSP-UI:  "jsp." prefix			   			   -->
+ <!-- The submission-definitions map lays out the detailed definition of     -->
+ <!-- all the Item Submission Processes (and the ordering of their steps).   -->
+ <!-- Each separate "submission-process" has a unique name as an attribute,  -->
+ <!-- which matches one of the names in the process-map. One named           -->
+ <!-- "submit-process" has the name "traditional"; as this name suggests,    -->
+ <!-- it is the default item submission process, which gets used when        -->
+ <!-- the specified collection has no correspondingly named submit-process.  -->
+ <!--                                                                        -->
+ <!-- Each submit-process contains an ordered set of steps; each step        -->
+ <!-- defines one "step" occurring during the process of submitting an       -->
+ <!-- item.  A step can either be referenced by 'id' (in which case it must  -->
+ <!-- be defined in <step-definitions> above), or defined completely here.   -->
+ <!--                                                                        -->
+ <!-- If the step is not referred to by 'id', then the <step> REQUIRES the   -->
+ <!-- following properties are defined:                                      --> 
+ <!-- <processing-class> - The class which will process all information for  -->
+ <!--             this step. The class must implement the                    -->
+ <!--             'org.dspace.app.webui.submit.JSPStep' interface AND        -->
+ <!--             extend 'org.dspace.submit.AbstractProcessingStep'          -->
+ <!--             (or one of the org.dspace.submit.step.* classes)           -->
+ <!--             This property should reference the full path of the class  -->
+ <!--              (e.g. org.dspace.app.webui.submit.MyCustomJSPStep)        -->
+ <!--                                                                        -->
+ <!-- The following properties are OPTIONAL for each <step>:                 -->
+ <!-- <heading> -    References the message key, from the                    -->
+ <!--                 Messages.properties file (JSP-UI) or messages.xml      -->
+ <!--                (XML-UI) which will be used as this step's heading in   -->
+ <!--                 the progress-bar.  If unspecified, the step does not   -->
+ <!--                 show up in the Progress Bar.  Keys in the <heading>    -->
+ <!--                 are prefixed as follows in the appropriate             -->
+ <!--                 "messages" file:                                       -->
+ <!--                        XML-UI:  "xmlui.Submission." prefix             -->
+ <!--                        JSP-UI:  "jsp." prefix                          -->
  <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
- <!--                 based user interface for this step.  The class must  -->
- <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.        -->
- <!--                 This property should reference the full path of the  -->
- <!--                 class.  It is only necessary if you are using the    -->
- <!--                 DSpace JSP-UI, and the step requires user interaction-->
- <!-- <xmlui-binding> - XML-UI binding step class which will generate the  -->
- <!--                 Manakin XML (DRI) structure for this step.  The class-->
- <!--                 must extend                                          -->
- <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.-->
- <!--                 This property should reference the full path of the  -->
- <!--                 class.  It is only necessary if you are using the    -->
- <!--                 DSpace XML-UI, and the step requires user interaction-->
- <!-- <workflow-editable> - whether or not this step will appear during the-->
- <!--				 "Edit Metadata" workflow approval process.  This field-->
- <!--				 defaults to TRUE (which means it can be edited during -->
- <!--				 the "Edit Metadata" workflow stage).  Set to either   -->
- <!--				 "true" or "false".				                       -->
- <!--                                                                      -->
+ <!--                 based user interface for this step.  The class must    -->
+ <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
+ <!--                 This property should reference the full path of the    -->
+ <!--                 class.  It is only necessary if you are using the      -->
+ <!--                 DSpace JSP-UI, and the step requires user interaction  -->
+ <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
+ <!--                 Manakin XML (DRI) structure for this step.  The class  -->
+ <!--                 must extend                                            -->
+ <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.  -->
+ <!--                 This property should reference the full path of the    -->
+ <!--                 class.  It is only necessary if you are using the      -->
+ <!--                 DSpace XML-UI, and the step requires user interaction  -->
+ <!-- <workflow-editable> - whether or not this step will appear during the  -->
+ <!--                 "Edit Metadata" workflow approval process.  This field -->
+ <!--                 defaults to TRUE (which means it can be edited during  -->
+ <!--                 the "Edit Metadata" workflow stage).  Set to either    -->
+ <!--                 "true" or "false".                                     -->
+ <!--                                                                        -->
  <submission-definitions>
 
      <!--This "traditional" process defines the DEFAULT item submission process-->
@@ -219,9 +217,6 @@
              <workflow-editable>true</workflow-editable>
          </step>
      </submission-process>
-
-
-
 
      <submission-process name="gallatin">
          <step>

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -7,308 +7,308 @@
 <!-- and number of the steps that occur in the Item Submission Process.      -->
 <item-submission>
 
- <!-- The process-map maps collection handles to a particular Item           -->
- <!-- Submission Process.  This requires that a collection's name be         -->
- <!-- unique, even within a community. DSpace does however ensure that each  -->
- <!-- collection's handle is unique.  Process-map provides the means to      -->
- <!-- associate a unique collection name with an Item Submission process.    -->
- <!-- The process-map also provides the special handle "default" (which is   -->
- <!-- never a collection), here mapped to "traditional". Any collection      -->
- <!-- which does not appear in this map will be associated with the mapping  -->
- <!-- for handle "default".                                                  -->
- <submission-map>
-   <name-map collection-handle="default"    submission-name="traditional" />
-   <name-map collection-handle="2451/34841" submission-name="gallatin"    />
+  <!-- The process-map maps collection handles to a particular Item           -->
+  <!-- Submission Process.  This requires that a collection's name be         -->
+  <!-- unique, even within a community. DSpace does however ensure that each  -->
+  <!-- collection's handle is unique.  Process-map provides the means to      -->
+  <!-- associate a unique collection name with an Item Submission process.    -->
+  <!-- The process-map also provides the special handle "default" (which is   -->
+  <!-- never a collection), here mapped to "traditional". Any collection      -->
+  <!-- which does not appear in this map will be associated with the mapping  -->
+  <!-- for handle "default".                                                  -->
+  <submission-map>
+    <name-map collection-handle="default"    submission-name="traditional" />
+    <name-map collection-handle="2451/34841" submission-name="gallatin"    />
 
-   <name-map collection-handle="2451/28318" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/28320" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29655" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29656" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29658" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29659" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29676" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29898" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/29947" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/33605" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/34304" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/34305" submission-name="rights-entry-on-dmd-form" />
-   <name-map collection-handle="2451/42113" submission-name="rights-entry-on-dmd-form" />
- </submission-map>
+    <name-map collection-handle="2451/28318" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/28320" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29655" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29656" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29658" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29659" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29676" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29898" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/29947" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/33605" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/34304" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/34305" submission-name="rights-entry-on-dmd-form" />
+    <name-map collection-handle="2451/42113" submission-name="rights-entry-on-dmd-form" />
+  </submission-map>
 
 
- <!-- The 'step-definitions' allows you to define steps which you may wish   -->
- <!-- to "share" amongst multiple submission-item definitions.  In order to  -->
- <!-- share the same step definition, you can refer to it by its unique id   -->
- <!-- defined in this section.  EVERY 'step' in this section MUST have a     -->
- <!-- unique identifier in the 'id' attribute!                               -->
- <!--                                                                        -->
- <!-- Each <step> REQUIRES the following attributes (@) and properties:      --> 
- <!-- @id                - The unique identifier for this step               -->
- <!--                                                                        -->
- <!-- <processing-class> - The class which will process all information for  -->
- <!--             this step. The class must extend                           -->
- <!--             'org.dspace.submit.AbstractProcessingStep'                 -->
- <!--             (or one of the org.dspace.submit.step.* classes)           -->
- <!--             This property should reference the full path of the class  -->
- <!--              (e.g. org.dspace.submit.step.MyCustomStep)                -->
- <!--                                                                        -->
- <!-- The following properties are OPTIONAL for each <step>:                 -->
- <!-- <heading> -    References the message key, from the                    -->
- <!--                Messages.properties file (JSP-UI) or messages.xml       -->
- <!--                (XML-UI) which will be used as this step's heading in   -->
- <!--                the progress-bar.  If unspecified, the step does not    -->
- <!--                show up in the Progress Bar.  Keys in the <heading>     -->
- <!--                are prefixed as follows in the appropriate              -->
- <!--                "messages" file:                                        -->
- <!--                  XML-UI:  "xmlui.Submission." prefix                 -->
- <!--                  JSP-UI:  "jsp." prefix                                -->
- <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
- <!--                 based user interface for this step.  The class must    -->
- <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
- <!--                 This property should reference the full path of the    -->
- <!--                 class.  It is only necessary if you are using the      -->
- <!--                 DSpace JSP-UI, and the step requires user interaction  -->
- <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
- <!--                 Manakin XML (DRI) structure for this step.  The class  -->
- <!--                 must extend                                            -->
- <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.-->
- <!--                 This property should reference the full path of the    -->
- <!--                 class.  It is only necessary if you are using the      -->
- <!--                 DSpace XML-UI, and the step requires user interaction  -->
- <!-- <workflow-editable> - whether or not this step will appear during the  -->
- <!--                 "Edit Metadata" workflow approval process.  This field -->
- <!--                 defaults to TRUE (which means it can be edited during  -->
- <!--                 the "Edit Metadata" workflow stage)                    -->
- <!--                                                                        -->
- <!--                                                                        -->
- <step-definitions>
-     <!-- The "collection" step is a "special step" which is *REQUIRED* to be-->
-     <!-- in this section!  In DSpace, all submitted items must be           -->
-     <!-- immediately assigned to a collection. This step ensures that a     -->
-     <!-- collection is always selected.  If a user is already submitting    -->
-     <!-- from within a Collection (by clicking the "Submit to This          -->
-     <!-- Collection" button) then this step will be automatically skipped.  -->
-     <!-- In all other cases, this step ensures that the user *first* selects-->
-     <!-- a collection!                                                      -->
-     <!-- Since this is a "special step", it is *automatically* added at the -->
-     <!-- beginning of each 'submission-process' (therefore it should not be -->
-     <!-- referenced by any of the below 'submission-process' tags).  Also as-->
-     <!-- a special step, it is currently NEVER editable in a workflow.      -->                              
-     <step id="collection">
-       <heading></heading> <!--can specify heading, if you want it to appear in Progress Bar-->
-       <processing-class>org.dspace.submit.step.SelectCollectionStep</processing-class>
-       <jspui-binding>org.dspace.app.webui.submit.step.JSPSelectCollectionStep</jspui-binding>
-       <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
-       <workflow-editable>false</workflow-editable>
-     </step>
-     
-     <!-- Uncomment this to make available the bibliographic import from external source - note ONLY for JSPUI -->     
-     <!-- <step id="collection">
-       <heading></heading> can specify heading, if you want it to appear in Progress Bar
-       <processing-class>org.dspace.submit.step.StartSubmissionLookupStep</processing-class>
-       <jspui-binding>org.dspace.app.webui.submit.step.JSPStartSubmissionLookupStep</jspui-binding>
-       <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
-       <workflow-editable>false</workflow-editable>
-     </step> -->
-   
-     <!-- The "complete" step is a "special step" which is *REQUIRED* to be-->
-     <!-- in this section!  In DSpace, when a submission is completed,       -->
-     <!-- a workflow is automatically kicked off (if one exists)             -->
-     <!-- This "complete" step performs all backend processing that occurs   -->
-     <!-- immediately upon completing the submission.                        -->
-     <!-- Since this is a "special step", it is *automatically* added at the -->
-     <!-- end of each 'submission-process' (therefore it should not be       -->
-     <!-- referenced by any of the below 'submission-process' tags).  Also as-->
-     <!-- a special step, it is currently NEVER editable in a workflow.      -->                               
-     <step id="complete">
-       <heading>submit.progressbar.complete</heading>
-       <processing-class>org.dspace.submit.step.CompleteStep</processing-class>
-       <jspui-binding>org.dspace.app.webui.submit.step.JSPCompleteStep</jspui-binding>
-       <workflow-editable>false</workflow-editable>
-     </step>
-   
-     <!-- This is the Sample Step which utilizes the JSPSampleStep class -->
-     <step id="sample">
-       <heading>Sample</heading>
-       <processing-class>org.dspace.submit.step.SampleStep</processing-class>
-       <jspui-binding>org.dspace.app.webui.submit.step.JSPSampleStep</jspui-binding>
-       <workflow-editable>true</workflow-editable>
-     </step>
- </step-definitions>
+  <!-- The 'step-definitions' allows you to define steps which you may wish   -->
+  <!-- to "share" amongst multiple submission-item definitions.  In order to  -->
+  <!-- share the same step definition, you can refer to it by its unique id   -->
+  <!-- defined in this section.  EVERY 'step' in this section MUST have a     -->
+  <!-- unique identifier in the 'id' attribute!                               -->
+  <!--                                                                        -->
+  <!-- Each <step> REQUIRES the following attributes (@) and properties:      --> 
+  <!-- @id                - The unique identifier for this step               -->
+  <!--                                                                        -->
+  <!-- <processing-class> - The class which will process all information for  -->
+  <!--             this step. The class must extend                           -->
+  <!--             'org.dspace.submit.AbstractProcessingStep'                 -->
+  <!--             (or one of the org.dspace.submit.step.* classes)           -->
+  <!--             This property should reference the full path of the class  -->
+  <!--              (e.g. org.dspace.submit.step.MyCustomStep)                -->
+  <!--                                                                        -->
+  <!-- The following properties are OPTIONAL for each <step>:                 -->
+  <!-- <heading> -    References the message key, from the                    -->
+  <!--                Messages.properties file (JSP-UI) or messages.xml       -->
+  <!--                (XML-UI) which will be used as this step's heading in   -->
+  <!--                the progress-bar.  If unspecified, the step does not    -->
+  <!--                show up in the Progress Bar.  Keys in the <heading>     -->
+  <!--                are prefixed as follows in the appropriate              -->
+  <!--                "messages" file:                                        -->
+  <!--                  XML-UI:  "xmlui.Submission." prefix                 -->
+  <!--                  JSP-UI:  "jsp." prefix                                -->
+  <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
+  <!--                 based user interface for this step.  The class must    -->
+  <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
+  <!--                 This property should reference the full path of the    -->
+  <!--                 class.  It is only necessary if you are using the      -->
+  <!--                 DSpace JSP-UI, and the step requires user interaction  -->
+  <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
+  <!--                 Manakin XML (DRI) structure for this step.  The class  -->
+  <!--                 must extend                                            -->
+  <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.-->
+  <!--                 This property should reference the full path of the    -->
+  <!--                 class.  It is only necessary if you are using the      -->
+  <!--                 DSpace XML-UI, and the step requires user interaction  -->
+  <!-- <workflow-editable> - whether or not this step will appear during the  -->
+  <!--                 "Edit Metadata" workflow approval process.  This field -->
+  <!--                 defaults to TRUE (which means it can be edited during  -->
+  <!--                 the "Edit Metadata" workflow stage)                    -->
+  <!--                                                                        -->
+  <!--                                                                        -->
+  <step-definitions>
+    <!-- The "collection" step is a "special step" which is *REQUIRED* to be-->
+    <!-- in this section!  In DSpace, all submitted items must be           -->
+    <!-- immediately assigned to a collection. This step ensures that a     -->
+    <!-- collection is always selected.  If a user is already submitting    -->
+    <!-- from within a Collection (by clicking the "Submit to This          -->
+    <!-- Collection" button) then this step will be automatically skipped.  -->
+    <!-- In all other cases, this step ensures that the user *first* selects-->
+    <!-- a collection!                                                      -->
+    <!-- Since this is a "special step", it is *automatically* added at the -->
+    <!-- beginning of each 'submission-process' (therefore it should not be -->
+    <!-- referenced by any of the below 'submission-process' tags).  Also as-->
+    <!-- a special step, it is currently NEVER editable in a workflow.      -->                              
+    <step id="collection">
+      <heading></heading> <!--can specify heading, if you want it to appear in Progress Bar-->
+      <processing-class>org.dspace.submit.step.SelectCollectionStep</processing-class>
+      <jspui-binding>org.dspace.app.webui.submit.step.JSPSelectCollectionStep</jspui-binding>
+      <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
+      <workflow-editable>false</workflow-editable>
+    </step>
+    
+    <!-- Uncomment this to make available the bibliographic import from external source - note ONLY for JSPUI -->     
+    <!-- <step id="collection">
+	 <heading></heading> can specify heading, if you want it to appear in Progress Bar
+	 <processing-class>org.dspace.submit.step.StartSubmissionLookupStep</processing-class>
+	 <jspui-binding>org.dspace.app.webui.submit.step.JSPStartSubmissionLookupStep</jspui-binding>
+	 <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.SelectCollectionStep</xmlui-binding>
+	 <workflow-editable>false</workflow-editable>
+	 </step> -->
+    
+    <!-- The "complete" step is a "special step" which is *REQUIRED* to be-->
+    <!-- in this section!  In DSpace, when a submission is completed,       -->
+    <!-- a workflow is automatically kicked off (if one exists)             -->
+    <!-- This "complete" step performs all backend processing that occurs   -->
+    <!-- immediately upon completing the submission.                        -->
+    <!-- Since this is a "special step", it is *automatically* added at the -->
+    <!-- end of each 'submission-process' (therefore it should not be       -->
+    <!-- referenced by any of the below 'submission-process' tags).  Also as-->
+    <!-- a special step, it is currently NEVER editable in a workflow.      -->                               
+    <step id="complete">
+      <heading>submit.progressbar.complete</heading>
+      <processing-class>org.dspace.submit.step.CompleteStep</processing-class>
+      <jspui-binding>org.dspace.app.webui.submit.step.JSPCompleteStep</jspui-binding>
+      <workflow-editable>false</workflow-editable>
+    </step>
+    
+    <!-- This is the Sample Step which utilizes the JSPSampleStep class -->
+    <step id="sample">
+      <heading>Sample</heading>
+      <processing-class>org.dspace.submit.step.SampleStep</processing-class>
+      <jspui-binding>org.dspace.app.webui.submit.step.JSPSampleStep</jspui-binding>
+      <workflow-editable>true</workflow-editable>
+    </step>
+  </step-definitions>
 
- <!-- The submission-definitions map lays out the detailed definition of     -->
- <!-- all the Item Submission Processes (and the ordering of their steps).   -->
- <!-- Each separate "submission-process" has a unique name as an attribute,  -->
- <!-- which matches one of the names in the process-map. One named           -->
- <!-- "submit-process" has the name "traditional"; as this name suggests,    -->
- <!-- it is the default item submission process, which gets used when        -->
- <!-- the specified collection has no correspondingly named submit-process.  -->
- <!--                                                                        -->
- <!-- Each submit-process contains an ordered set of steps; each step        -->
- <!-- defines one "step" occurring during the process of submitting an       -->
- <!-- item.  A step can either be referenced by 'id' (in which case it must  -->
- <!-- be defined in <step-definitions> above), or defined completely here.   -->
- <!--                                                                        -->
- <!-- If the step is not referred to by 'id', then the <step> REQUIRES the   -->
- <!-- following properties are defined:                                      --> 
- <!-- <processing-class> - The class which will process all information for  -->
- <!--             this step. The class must implement the                    -->
- <!--             'org.dspace.app.webui.submit.JSPStep' interface AND        -->
- <!--             extend 'org.dspace.submit.AbstractProcessingStep'          -->
- <!--             (or one of the org.dspace.submit.step.* classes)           -->
- <!--             This property should reference the full path of the class  -->
- <!--              (e.g. org.dspace.app.webui.submit.MyCustomJSPStep)        -->
- <!--                                                                        -->
- <!-- The following properties are OPTIONAL for each <step>:                 -->
- <!-- <heading> -    References the message key, from the                    -->
- <!--                 Messages.properties file (JSP-UI) or messages.xml      -->
- <!--                (XML-UI) which will be used as this step's heading in   -->
- <!--                 the progress-bar.  If unspecified, the step does not   -->
- <!--                 show up in the Progress Bar.  Keys in the <heading>    -->
- <!--                 are prefixed as follows in the appropriate             -->
- <!--                 "messages" file:                                       -->
- <!--                        XML-UI:  "xmlui.Submission." prefix             -->
- <!--                        JSP-UI:  "jsp." prefix                          -->
- <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
- <!--                 based user interface for this step.  The class must    -->
- <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
- <!--                 This property should reference the full path of the    -->
- <!--                 class.  It is only necessary if you are using the      -->
- <!--                 DSpace JSP-UI, and the step requires user interaction  -->
- <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
- <!--                 Manakin XML (DRI) structure for this step.  The class  -->
- <!--                 must extend                                            -->
- <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.  -->
- <!--                 This property should reference the full path of the    -->
- <!--                 class.  It is only necessary if you are using the      -->
- <!--                 DSpace XML-UI, and the step requires user interaction  -->
- <!-- <workflow-editable> - whether or not this step will appear during the  -->
- <!--                 "Edit Metadata" workflow approval process.  This field -->
- <!--                 defaults to TRUE (which means it can be edited during  -->
- <!--                 the "Edit Metadata" workflow stage).  Set to either    -->
- <!--                 "true" or "false".                                     -->
- <!--                                                                        -->
- <submission-definitions>
+  <!-- The submission-definitions map lays out the detailed definition of     -->
+  <!-- all the Item Submission Processes (and the ordering of their steps).   -->
+  <!-- Each separate "submission-process" has a unique name as an attribute,  -->
+  <!-- which matches one of the names in the process-map. One named           -->
+  <!-- "submit-process" has the name "traditional"; as this name suggests,    -->
+  <!-- it is the default item submission process, which gets used when        -->
+  <!-- the specified collection has no correspondingly named submit-process.  -->
+  <!--                                                                        -->
+  <!-- Each submit-process contains an ordered set of steps; each step        -->
+  <!-- defines one "step" occurring during the process of submitting an       -->
+  <!-- item.  A step can either be referenced by 'id' (in which case it must  -->
+  <!-- be defined in <step-definitions> above), or defined completely here.   -->
+  <!--                                                                        -->
+  <!-- If the step is not referred to by 'id', then the <step> REQUIRES the   -->
+  <!-- following properties are defined:                                      --> 
+  <!-- <processing-class> - The class which will process all information for  -->
+  <!--             this step. The class must implement the                    -->
+  <!--             'org.dspace.app.webui.submit.JSPStep' interface AND        -->
+  <!--             extend 'org.dspace.submit.AbstractProcessingStep'          -->
+  <!--             (or one of the org.dspace.submit.step.* classes)           -->
+  <!--             This property should reference the full path of the class  -->
+  <!--              (e.g. org.dspace.app.webui.submit.MyCustomJSPStep)        -->
+  <!--                                                                        -->
+  <!-- The following properties are OPTIONAL for each <step>:                 -->
+  <!-- <heading> -    References the message key, from the                    -->
+  <!--                 Messages.properties file (JSP-UI) or messages.xml      -->
+  <!--                (XML-UI) which will be used as this step's heading in   -->
+  <!--                 the progress-bar.  If unspecified, the step does not   -->
+  <!--                 show up in the Progress Bar.  Keys in the <heading>    -->
+  <!--                 are prefixed as follows in the appropriate             -->
+  <!--                 "messages" file:                                       -->
+  <!--                        XML-UI:  "xmlui.Submission." prefix             -->
+  <!--                        JSP-UI:  "jsp." prefix                          -->
+  <!-- <jspui-binding> - JSP-UI binding step class which will generate the JSP-->
+  <!--                 based user interface for this step.  The class must    -->
+  <!--                 extend 'org.dspace.app.webui.submit.JSPStep'.          -->
+  <!--                 This property should reference the full path of the    -->
+  <!--                 class.  It is only necessary if you are using the      -->
+  <!--                 DSpace JSP-UI, and the step requires user interaction  -->
+  <!-- <xmlui-binding> - XML-UI binding step class which will generate the    -->
+  <!--                 Manakin XML (DRI) structure for this step.  The class  -->
+  <!--                 must extend                                            -->
+  <!--                 'org.dspace.app.xmlui.aspect.submission.StepTransformer'.  -->
+  <!--                 This property should reference the full path of the    -->
+  <!--                 class.  It is only necessary if you are using the      -->
+  <!--                 DSpace XML-UI, and the step requires user interaction  -->
+  <!-- <workflow-editable> - whether or not this step will appear during the  -->
+  <!--                 "Edit Metadata" workflow approval process.  This field -->
+  <!--                 defaults to TRUE (which means it can be edited during  -->
+  <!--                 the "Edit Metadata" workflow stage).  Set to either    -->
+  <!--                 "true" or "false".                                     -->
+  <!--                                                                        -->
+  <submission-definitions>
 
-     <!--This "traditional" process defines the DEFAULT item submission process-->
-     <submission-process name="traditional">
-         <step>
-             <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
-         </step>
-         <step>
-             <heading>submit.progressbar.license</heading>
-             <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
-             <workflow-editable>false</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.upload</heading>
-             <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.describe</heading>
-             <processing-class>org.dspace.submit.step.DescribeStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.access</heading>
-             <processing-class>org.dspace.submit.step.AccessStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPAccessStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.AccessStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.verify</heading>
-             <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-     </submission-process>
+    <!--This "traditional" process defines the DEFAULT item submission process-->
+    <submission-process name="traditional">
+      <step>
+        <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
+      </step>
+      <step>
+        <heading>submit.progressbar.license</heading>
+        <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
+        <workflow-editable>false</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.upload</heading>
+        <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.describe</heading>
+        <processing-class>org.dspace.submit.step.DescribeStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.access</heading>
+        <processing-class>org.dspace.submit.step.AccessStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPAccessStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.AccessStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.verify</heading>
+        <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+    </submission-process>
 
-     <!-- This submission process uses a DMD form that includes rights entry   -->
-     <!-- instead of having rights entry as a separate step          -->
-     <submission-process name="rights-entry-on-dmd-form">
-         <step>
-             <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
-         </step>
-         <step>
-             <heading>submit.progressbar.license</heading>
-             <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
-             <workflow-editable>false</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.upload</heading>
-             <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.describe</heading>
-             <processing-class>org.dspace.submit.step.DescribeStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.access</heading>
-             <processing-class>org.dspace.submit.step.AccessStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPAccessStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.AccessStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.verify</heading>
-             <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-     </submission-process>
+    <!-- This submission process uses a DMD form that includes rights entry   -->
+    <!-- instead of having rights entry as a separate step          -->
+    <submission-process name="rights-entry-on-dmd-form">
+      <step>
+        <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
+      </step>
+      <step>
+        <heading>submit.progressbar.license</heading>
+        <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
+        <workflow-editable>false</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.upload</heading>
+        <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.describe</heading>
+        <processing-class>org.dspace.submit.step.DescribeStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.access</heading>
+        <processing-class>org.dspace.submit.step.AccessStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPAccessStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.AccessStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.verify</heading>
+        <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+    </submission-process>
 
-     <submission-process name="gallatin">
-         <step>
-             <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
-         </step>
-         <step>
-             <heading>submit.progressbar.license</heading>
-             <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
-             <workflow-editable>false</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.upload</heading>
-             <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.describe</heading>
-             <processing-class>org.dspace.submit.step.DescribeStepNYU</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeNYUStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-         <step>
-             <heading>submit.progressbar.verify</heading>
-             <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
-             <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
-             <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
-             <workflow-editable>true</workflow-editable>
-         </step>
-     </submission-process>
+    <submission-process name="gallatin">
+      <step>
+        <processing-class>org.dspace.submit.step.SkipInitialQuestionsStep</processing-class>
+      </step>
+      <step>
+        <heading>submit.progressbar.license</heading>
+        <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPLicenseStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
+        <workflow-editable>false</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.upload</heading>
+        <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.describe</heading>
+        <processing-class>org.dspace.submit.step.DescribeStepNYU</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPDescribeNYUStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.DescribeStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.verify</heading>
+        <processing-class>org.dspace.submit.step.VerifyStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPVerifyStep</jspui-binding>
+        <xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.ReviewStep</xmlui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+    </submission-process>
 
- </submission-definitions>
+  </submission-definitions>
 
 </item-submission>


### PR DESCRIPTION
## Overview
* Implement changes to `input-forms.xml` and `item-submission.xml` so that the UX does not change for submitters to collections that have template items with rights statements.
* Please review the git commit messages for details on the steps taken to implement these changes.
* These changes were made in preparation for parent ticket FDA-196, in which and explicit rights statement entry step will be added to the submission process for all collections not included in this ticket.